### PR TITLE
Add grey bar to top of archived threads

### DIFF
--- a/src/braid/ui/styles/thread.cljs
+++ b/src/braid/ui/styles/thread.cljs
@@ -34,17 +34,17 @@
       :top 0
       :left 0}]
 
+      [:&.archived
+       [:.head:before
+        {:background vars/archived-thread-accent-color}]]
+
       [:&.private
        [:.head:before
         {:background vars/private-thread-accent-color}]]
 
       [:&.limbo
        [:.head:before
-        {:background vars/limbo-thread-accent-color}]]
-
-      [:&.archived
-       [:.head:before
-        {:background vars/archived-thread-accent-color}]]]
+        {:background vars/limbo-thread-accent-color}]]]
 
    [:.card
     mixins/flex

--- a/src/braid/ui/styles/thread.cljs
+++ b/src/braid/ui/styles/thread.cljs
@@ -36,15 +36,15 @@
 
       [:&.private
        [:.head:before
-        {:background "#5f7997"}]]
+        {:background vars/private-thread-accent-color}]]
 
       [:&.limbo
        [:.head:before
-        {:background "#CA1414"}]]
+        {:background vars/limbo-thread-accent-color}]]
 
       [:&.archived
        [:.head:before
-        {:background "#AAAAAA"}]]]
+        {:background vars/archived-thread-accent-color}]]]
 
    [:.card
     mixins/flex
@@ -78,7 +78,7 @@
    [:&.private
     [:.notice
      {:background "#D2E7FF"
-      :color "#5f7997"}
+      :color vars/private-thread-accent-color}
 
      [:&:before
       (mixins/fontawesome \uf21b)]]]
@@ -86,7 +86,7 @@
    [:&.limbo
     [:.notice
      {:background "#ffe4e4"
-      :color "#CA1414"}
+      :color vars/limbo-thread-accent-color}
 
      [:&:before
       (mixins/fontawesome \uf071)]]]])

--- a/src/braid/ui/styles/thread.cljs
+++ b/src/braid/ui/styles/thread.cljs
@@ -19,9 +19,32 @@
 
    [:&.new
     {:z-index 99}]
+
    [:&:before ; switch to :after to align at top
     {:content "\"\""
      :flex-grow 1}]
+
+   [:&.archived :&.limbo :&.private
+    [:.head:before
+     {:content "\"\""
+      :display "block"
+      :width "100%"
+      :height (px 5)
+      :position "absolute"
+      :top 0
+      :left 0}]
+
+      [:&.private
+       [:.head:before
+        {:background "#5f7997"}]]
+
+      [:&.limbo
+       [:.head:before
+        {:background "#CA1414"}]]
+
+      [:&.archived
+       [:.head:before
+        {:background "#AAAAAA"}]]]
 
    [:.card
     mixins/flex
@@ -50,21 +73,9 @@
     [:.card
      {; needs to be a better way
       ; which is based on the height of the notice
-      :max-height "85%"}]
-
-    [:.head:before
-     {:content "\"\""
-      :display "block"
-      :width "100%"
-      :height (px 5)
-      :position "absolute"
-      :top 0
-      :left 0}]]
+      :max-height "85%"}]]
 
    [:&.private
-    [:.head:before
-     {:background "#5f7997"}]
-
     [:.notice
      {:background "#D2E7FF"
       :color "#5f7997"}
@@ -73,9 +84,6 @@
       (mixins/fontawesome \uf21b)]]]
 
    [:&.limbo
-    [:.head:before
-     {:background "#CA1414"}]
-
     [:.notice
      {:background "#ffe4e4"
       :color "#CA1414"}

--- a/src/braid/ui/styles/vars.cljs
+++ b/src/braid/ui/styles/vars.cljs
@@ -18,3 +18,9 @@
 (def dark-bg-color "#3A4767")
 
 (def border-radius (px 3))
+
+(def private-thread-accent-color "#5f7997")
+
+(def limbo-thread-accent-color "#CA1414")
+
+(def archived-thread-accent-color "#AAAAAA")

--- a/src/braid/ui/views/thread.cljs
+++ b/src/braid/ui/views/thread.cljs
@@ -118,7 +118,8 @@
       (let [{:keys [dragging? uploading? focused?]} @state
             new? (thread :new?)
             private? (thread-private? thread)
-            limbo? (thread-limbo? thread)]
+            limbo? (thread-limbo? thread)
+            archived? (and (not @open?) (not new?))]
 
         [:div.thread
          {:class
@@ -126,7 +127,8 @@
                             (when private? "private")
                             (when limbo? "limbo")
                             (when focused? "focused")
-                            (when dragging? "dragging")])
+                            (when dragging? "dragging")
+                            (when archived? "archived")])
 
           :on-click (fn [e]
                       (put! focus-chan (js/Date.))


### PR DESCRIPTION
I added a grey bar to the top of archived threads to make them more visually distinct from open threads.

This also helps users distinguish when they are in the inbox vs. when they are not.
![screen shot 2016-06-01 at 5 16 08 pm](https://cloud.githubusercontent.com/assets/1787094/15726021/994c219a-281c-11e6-8b5d-94b006978cc2.png)


Fixes https://github.com/braidchat/meta/issues/449 and https://github.com/braidchat/meta/issues/451