### PR TITLE
Add round corners to error bars so they would match the thread

### DIFF
--- a/src/braid/ui/styles/thread.cljs
+++ b/src/braid/ui/styles/thread.cljs
@@ -32,7 +32,9 @@
       :height (px 5)
       :position "absolute"
       :top 0
-      :left 0}]
+      :left 0
+      :border-radius [[vars/border-radius
+                       vars/border-radius 0 0]]}]
 
       [:&.archived
        [:.head:before


### PR DESCRIPTION
I wanted the top notification bars to match the shape of the thread cards.