### PR TITLE
Husl colors

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -104,7 +104,8 @@
 
   :profiles {:dev {:dependencies [[com.datomic/datomic-free "0.9.5201"
                                    :exclusions [joda-time
-                                                com.amazonaws/aws-java-sdk]]
+                                                com.amazonaws/aws-java-sdk
+                                                com.google.guava/guava]]
                                   [figwheel-sidecar "0.5.0-6"
                                    :exclusions
                                    [org.clojure/google-closure-library-third-party

--- a/project.clj
+++ b/project.clj
@@ -31,6 +31,7 @@
                  [com.andrewmcveigh/cljs-time "0.4.0"]
                  [clj-fuzzy "0.3.1"]
                  [reagent "0.5.1"]
+                 [cljsjs/husl "6.0.1-0"]
                  ;shared
                  [org.clojure/tools.reader "1.0.0-beta1"]
                  [org.clojure/core.async "0.2.374" :exclusions [org.clojure/tools.reader]]

--- a/src/chat/client/views/helpers.cljs
+++ b/src/chat/client/views/helpers.cljs
@@ -4,10 +4,11 @@
             [cljs-time.format :as f]
             [cljs-time.core :as t]
             [chat.client.store :as store]
-            [goog.style :as gstyle]))
+            [goog.style :as gstyle]
+            [cljsjs.husl]))
 
 (defn ->color [input]
-  (str "hsl(" (mod (Math/abs (hash input)) 360) ",71%,35%)"))
+  (js/window.HUSL.toHex (mod (Math/abs (hash input)) 360) 95 50))
 
 (defn id->color [uuid]
   (->color uuid))


### PR DESCRIPTION
I finally got around to wrapping the HUSL library w/ cljsjs:
https://github.com/cljsjs/packages/pull/607

Info about the library here:
 - http://www.husl-colors.org/
 - https://github.com/husl-colors/husl

Randomly generated colors will now have constant perceived brightness, and therefore, all generated colors will work well as a background for white text.

Until cljsjs accepts the PR and cuts an official release, you can install it locally (to build) as follows:

1. clone my fork: `git clone git@github.com:rafd/packages.git`
2. `cd packages/husl`
3. `boot package pom jar install`

(if you don't have boot, then `brew install boot-clj`)

