### PR TITLE
Use same method to generate message link colors and website embed backgrounds

### DIFF
--- a/src/braid/ui/styles/thread.cljs
+++ b/src/braid/ui/styles/thread.cljs
@@ -148,14 +148,23 @@
      :cursor "pointer"
      :color "#e6e6e6"
      :box-shadow "0 0 1px 1px #e6e6e6"}
+
     [:&:after
-     (mixins/fontawesome \uf067)]
+     {:position "absolute"
+      :top "50%"
+      :left 0
+      :width "100%"
+      :margin-top (em -1)}
+      (mixins/fontawesome \uf067)]
+
     [:&:hover
      {:color "#ccc"
       :box-shadow "0 0 1px 1px #ccc"}]
+
     [:&:active
      {:color "#999"
       :box-shadow "0 0 1px 1px #999"}]
+
     [:&.uploading:after
      (mixins/fontawesome \uf110)
      mixins/spin]]

--- a/src/braid/ui/views/embed.cljs
+++ b/src/braid/ui/views/embed.cljs
@@ -2,7 +2,7 @@
   (:require [reagent.core :as r]
             [clojure.string :as string]
             [chat.client.xhr :refer [edn-xhr]]
-            [chat.client.views.helpers :refer [->color url->parts]]))
+            [chat.client.views.helpers :refer [->color url->color]]))
 
 (defn- arr->rgb [arr]
   ; until embedly provides color alpha, default to transparent background
@@ -13,11 +13,7 @@
 
 (defn- website-embed-view [content]
   [:div.content.loaded.website
-   {:style {:background-color (-> (content :original_url)
-                                  string/lower-case
-                                  url->parts
-                                  :domain
-                                  ->color)}}
+   {:style {:background-color (url->color (content :original_url))}}
    (if-let [img (get-in content [:images 0])]
      [:img.image {:src (img :url)
                   :style {:background-color

--- a/src/braid/ui/views/embed.cljs
+++ b/src/braid/ui/views/embed.cljs
@@ -1,7 +1,8 @@
 (ns braid.ui.views.embed
   (:require [reagent.core :as r]
+            [clojure.string :as string]
             [chat.client.xhr :refer [edn-xhr]]
-            [chat.client.views.helpers :refer [->color]]))
+            [chat.client.views.helpers :refer [->color url->parts]]))
 
 (defn- arr->rgb [arr]
   ; until embedly provides color alpha, default to transparent background
@@ -12,7 +13,11 @@
 
 (defn- website-embed-view [content]
   [:div.content.loaded.website
-   {:style {:background-color (->color (content :provider_name))}}
+   {:style {:background-color (-> (content :original_url)
+                                  string/lower-case
+                                  url->parts
+                                  :domain
+                                  ->color)}}
    (if-let [img (get-in content [:images 0])]
      [:img.image {:src (img :url)
                   :style {:background-color

--- a/src/braid/ui/views/message.cljs
+++ b/src/braid/ui/views/message.cljs
@@ -31,10 +31,7 @@
                (let [url (string/lower-case match)]
                  [:a.external {:href url
                                :title url
-                               :style {:background-color  (-> url
-                                                              helpers/url->parts
-                                                              :domain
-                                                              ->color)}
+                               :style {:background-color  (helpers/url->color url)}
                                :target "_blank"
                                ; rel to address vuln caused by target=_blank
                                ; https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/

--- a/src/braid/ui/views/message.cljs
+++ b/src/braid/ui/views/message.cljs
@@ -11,16 +11,11 @@
             [chat.client.views.helpers :as helpers]
             [chat.client.routes :as routes]))
 
-(defn url->parts [url]
-  (let [[domain path] (rest (re-find #"http(?:s)?://([^/]+)(.*)" url))]
-    {:domain domain
-     :path path}))
-
 (defn abridged-url
   "Given a full url, returns 'domain.com/*.png' where"
   [url]
   (let [char-limit 30
-        {:keys [domain path]} (url->parts url)]
+        {:keys [domain path]} (helpers/url->parts url)]
     (let [url-and-path (str domain path)]
       (if (> char-limit (count url-and-path))
         url-and-path
@@ -29,16 +24,16 @@
               abridged-path (apply str (take-last path-char-limit path))]
           (str domain gap abridged-path))))))
 
-(defn url->domain [url]
-  ((url->parts url) :domain))
-
 (def replacements
   {:urls
    {:pattern helpers/url-re
     :replace (fn [match]
                [:a.external {:href match
                              :title match
-                             :style {:background-color (->color (url->domain match))}
+                             :style {:background-color  (-> match
+                                                            helpers/url->parts
+                                                            :domain
+                                                            ->color)}
                              :target "_blank"
                              ; rel to address vuln caused by target=_blank
                              ; https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/

--- a/src/braid/ui/views/message.cljs
+++ b/src/braid/ui/views/message.cljs
@@ -28,18 +28,19 @@
   {:urls
    {:pattern helpers/url-re
     :replace (fn [match]
-               [:a.external {:href match
-                             :title match
-                             :style {:background-color  (-> match
-                                                            helpers/url->parts
-                                                            :domain
-                                                            ->color)}
-                             :target "_blank"
-                             ; rel to address vuln caused by target=_blank
-                             ; https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/
-                             :rel "noopener noreferrer"
-                             :tabIndex -1}
-                 (abridged-url match)])}
+               (let [url (string/lower-case match)]
+                 [:a.external {:href url
+                               :title url
+                               :style {:background-color  (-> url
+                                                              helpers/url->parts
+                                                              :domain
+                                                              ->color)}
+                               :target "_blank"
+                               ; rel to address vuln caused by target=_blank
+                               ; https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/
+                               :rel "noopener noreferrer"
+                               :tabIndex -1}
+                  (abridged-url url)]))}
    :users
    {:pattern #"@([-0-9a-z]+)"
     :replace (fn [match]

--- a/src/chat/client/views/helpers.cljs
+++ b/src/chat/client/views/helpers.cljs
@@ -81,3 +81,8 @@
 
 (defn contains-urls? [text]
   (boolean (seq (extract-urls text))))
+
+(defn url->parts [url]
+  (let [[domain path] (rest (re-find #"http(?:s)?://([^/]+)(.*)" url))]
+    {:domain domain
+     :path path}))

--- a/src/chat/client/views/helpers.cljs
+++ b/src/chat/client/views/helpers.cljs
@@ -5,7 +5,8 @@
             [cljs-time.core :as t]
             [chat.client.store :as store]
             [goog.style :as gstyle]
-            [cljsjs.husl]))
+            [cljsjs.husl])
+  (:import [goog Uri]))
 
 (defn ->color [input]
   (js/window.HUSL.toHex (mod (Math/abs (hash input)) 360) 95 50))
@@ -83,6 +84,6 @@
   (boolean (seq (extract-urls text))))
 
 (defn url->parts [url]
-  (let [[domain path] (rest (re-find #"http(?:s)?://([^/]+)(.*)" url))]
-    {:domain domain
-     :path path}))
+  (let [url-info (.parse Uri url)]
+    {:domain (.getDomain url-info)
+     :path (.getPath url-info)}))

--- a/src/chat/client/views/helpers.cljs
+++ b/src/chat/client/views/helpers.cljs
@@ -1,18 +1,13 @@
 (ns chat.client.views.helpers
   (:require-macros [cljs.core.async.macros :refer [go]])
   (:require [cljs.core.async :refer [<! put! chan alts! timeout]]
+            [clojure.string :as string]
             [cljs-time.format :as f]
             [cljs-time.core :as t]
             [chat.client.store :as store]
             [goog.style :as gstyle]
             [cljsjs.husl])
   (:import [goog Uri]))
-
-(defn ->color [input]
-  (js/window.HUSL.toHex (mod (Math/abs (hash input)) 360) 95 50))
-
-(defn id->color [uuid]
-  (->color uuid))
 
 (defn format-date
   "Turn a Date object into a nicely formatted string"
@@ -87,3 +82,16 @@
   (let [url-info (.parse Uri url)]
     {:domain (.getDomain url-info)
      :path (.getPath url-info)}))
+
+(defn ->color [input]
+  (js/window.HUSL.toHex (mod (Math/abs (hash input)) 360) 95 50))
+
+(defn id->color [uuid]
+  (->color uuid))
+
+(defn url->color [url]
+  (-> url
+      string/lower-case
+      url->parts
+      :domain
+      ->color))


### PR DESCRIPTION
Using domain of a link to generate the color in both cases.

Addresses: https://github.com/braidchat/meta/issues/495

<img width="293" alt="screenshot 2016-06-10 06 38 57" src="https://cloud.githubusercontent.com/assets/89664/15962016/348fb062-2ed6-11e6-8be2-602881fcef1e.png">
