### PR TITLE
Improve styling of close button

### DIFF
--- a/src/braid/ui/styles/thread.cljs
+++ b/src/braid/ui/styles/thread.cljs
@@ -113,31 +113,36 @@
       {:margin-bottom (em 0.5)
        :margin-right (em 0.5)} ] ]
 
-    [".controls:hover > .unsub"
-     {:display "block"}]
     [:.controls
-     [:.unsub
-      {:position "absolute"
-       :padding (m/* 0.5 pad)
-       :top (m/* -1.5 pad)
-       :right 0
-       :z-index 10
-       :cursor "pointer"
-       :font-family "fontawesome"
-       :color "rgb(224, 114, 116)"
-       :background-color "white"
-       :border-radius (px 5)
-       :display "none"}]
+     {:position "absolute"
+      :padding pad
+      :top 0
+      :right 0
+      :z-index 10
+      :color "#CCC"
+      :text-align "right"}
 
-     [:.close
-      {:position "absolute"
-       :padding (m/* 0.5 pad)
-       :top 0
-       :right 0
-       :z-index 10
-       :cursor "pointer"
-       :font-family "fontawesome"
-       :color "rgb(88, 88, 88)"}]]]])
+     [:.control
+      {:cursor "pointer"}
+
+      [:&:hover
+       {:color "#333"}]
+
+      [:&.close
+       [:&:after
+        (mixins/fontawesome \uf00d)]]
+
+      [:&.mute
+       {:margin-top (m/* pad 0.5)}
+       {:display "none"}
+
+       [:&:after
+        {:font-size "0.9em"
+         :margin-right "-0.15em"}
+        (mixins/fontawesome \uf1f6)]]]]
+
+    [".controls:hover > .mute"
+     {:display "block"}]]])
 
 (defn messages [pad]
   [:.thread

--- a/src/braid/ui/views/thread.cljs
+++ b/src/braid/ui/views/thread.cljs
@@ -199,15 +199,16 @@
           [:div.head
            (when (and (not new?) @open?)
              [:div.controls
-              [:div.unsub
-               {:on-click (fn [_] (dispatch! :unsub-thread
-                                             {:thread-id (thread :id)}))
-                :title "Unsubscribe"}
-               "\uf1f7"]
-              [:div.close
-               {:on-click (fn [_]
-                            (dispatch! :hide-thread {:thread-id (thread :id)}))}
-               "\uf00d"]])
+              [:div.control.close
+               {:title "Close"
+                :on-click (fn [_]
+                            (dispatch! :hide-thread {:thread-id (thread :id)}))}]
+
+              [:div.control.mute
+               {:title "Mute"
+                :on-click (fn [_] (dispatch! :unsub-thread
+                                             {:thread-id (thread :id)}))}]])
+
            [thread-tags-view thread]]
 
           (when-not new?


### PR DESCRIPTION
A few more tweaks to the close / mute styling:

<img width="318" alt="screenshot 2016-06-16 17 07 03" src="https://cloud.githubusercontent.com/assets/89664/16133244/cacb71ca-33e4-11e6-913d-64698141d8db.png">
