### PR TITLE
Db name refactor

### DIFF
--- a/src/braid/common/notify_rules.clj
+++ b/src/braid/common/notify_rules.clj
@@ -9,7 +9,7 @@
 
 (defn thread->tags
   [thread-id]
-  (:tag-ids (db/get-thread thread-id)))
+  (:tag-ids (db/thread-by-id thread-id)))
 
 (defn thread->groups [thread-id]
   (into #{} (map tag->group) (thread->tags thread-id)))

--- a/src/braid/server/db/group.clj
+++ b/src/braid/server/db/group.clj
@@ -72,7 +72,7 @@
             (d/db conn) group-id)
        (map (comp db->tag first))))
 
-(defn get-groups-for-user [conn user-id]
+(defn user-groups [conn user-id]
   (->> (d/q '[:find [?g ...]
               :in $ ?user-id
               :where

--- a/src/braid/server/db/group.clj
+++ b/src/braid/server/db/group.clj
@@ -59,7 +59,7 @@
     (when (:public? (group-settings conn (group :id)))
       group)))
 
-(defn get-group-tags
+(defn group-tags
   [conn group-id]
   (->> (d/q '[:find (pull ?t [:tag/id
                               :tag/name

--- a/src/braid/server/db/group.clj
+++ b/src/braid/server/db/group.clj
@@ -20,7 +20,8 @@
   (-> (d/pull (d/db conn) group-pull-pattern [:group/id group-id])
       db->group))
 
-(defn get-users-in-group [conn group-id]
+(defn group-users
+  [conn group-id]
   (->> (d/q '[:find (pull ?u pull-pattern)
               :in $ ?group-id pull-pattern
               :where

--- a/src/braid/server/db/group.clj
+++ b/src/braid/server/db/group.clj
@@ -15,7 +15,7 @@
        (create-entity! conn)
        db->group))
 
-(defn get-group
+(defn group-by-id
   [conn group-id]
   (-> (d/pull (d/db conn) group-pull-pattern [:group/id group-id])
       db->group))

--- a/src/braid/server/db/invitation.clj
+++ b/src/braid/server/db/invitation.clj
@@ -12,7 +12,7 @@
        (create-entity! conn)
        db->invitation))
 
-(defn get-invite
+(defn invite-by-id
   [conn invite-id]
   (some-> (d/pull (d/db conn)
                   [:invite/id

--- a/src/braid/server/db/invitation.clj
+++ b/src/braid/server/db/invitation.clj
@@ -26,7 +26,7 @@
   [conn invite-id]
   @(d/transact conn [[:db.fn/retractEntity [:invite/id invite-id]]]))
 
-(defn fetch-invitations-for-user
+(defn invites-for-user
   [conn user-id]
   (->> (d/q '[:find (pull ?i [{:invite/group [:group/id :group/name]}
                               {:invite/from [:user/id :user/email :user/nickname]}

--- a/src/braid/server/db/message.clj
+++ b/src/braid/server/db/message.clj
@@ -45,7 +45,7 @@
                                   (fn [user-id]
                                     [:db/add [:user/id user-id]
                                      :user/open-thread [:thread/id thread-id]])
-                                  (thread/get-users-subscribed-to-thread conn thread-id))
+                                  (thread/users-subscribed-to-thread conn thread-id))
         ; upsert message
         msg-data {:db/id (d/tempid :entities)
                   :message/id id

--- a/src/braid/server/db/message.clj
+++ b/src/braid/server/db/message.clj
@@ -28,7 +28,7 @@
                                               [:db/add [:user/id user-id]
                                                :user/open-thread
                                                [:thread/id thread-id]]])
-                                           (tag/get-users-subscribed-to-tag conn tag-id))))
+                                           (tag/users-subscribed-to-tag conn tag-id))))
                                mentioned-tag-ids)
         ; subscribe and open thread for users mentioned
         txs-for-user-mentions (mapcat

--- a/src/braid/server/db/tag.clj
+++ b/src/braid/server/db/tag.clj
@@ -65,7 +65,7 @@
                        :tag/subscribers-count subscribers-count}]))
        (into {})))
 
-(defn fetch-tags-for-user
+(defn tags-for-user
   "Get all tags visible to the given user"
   [conn user-id]
   (let [tag-stats (tag-statistics-for-user conn user-id)]

--- a/src/braid/server/db/tag.clj
+++ b/src/braid/server/db/tag.clj
@@ -19,7 +19,7 @@
   @(d/transact conn [[:db/add [:tag/id tag-id]
                       :tag/description description]]))
 
-(defn get-users-subscribed-to-tag
+(defn users-subscribed-to-tag
   [conn tag-id]
   (d/q '[:find [?user-id ...]
          :in $ ?tag-id

--- a/src/braid/server/db/tag.clj
+++ b/src/braid/server/db/tag.clj
@@ -45,7 +45,7 @@
        (map first)
        set))
 
-(defn fetch-tag-statistics-for-user
+(defn tag-statistics-for-user
   [conn user-id]
   (->> (d/q '[:find
               ?tag-id
@@ -68,7 +68,7 @@
 (defn fetch-tags-for-user
   "Get all tags visible to the given user"
   [conn user-id]
-  (let [tag-stats (fetch-tag-statistics-for-user conn user-id)]
+  (let [tag-stats (tag-statistics-for-user conn user-id)]
     (->> (d/q '[:find
                 (pull ?t [:tag/id
                           :tag/name

--- a/src/braid/server/db/tag.clj
+++ b/src/braid/server/db/tag.clj
@@ -30,7 +30,9 @@
        (d/db conn)
        tag-id))
 
-(defn get-user-visible-tag-ids
+(defn tag-ids-for-user
+  "Get all tag ids that are accessible to the user (i.e. are from groups that
+  the user is a member of"
   [conn user-id]
   (->> (d/q '[:find ?tag-id
               :in $ ?user-id

--- a/src/braid/server/db/tag.clj
+++ b/src/braid/server/db/tag.clj
@@ -107,7 +107,7 @@
   @(d/transact conn [[:db/retract [:user/id user-id]
                       :user/subscribed-tag [:tag/id tag-id]]]))
 
-(defn get-user-subscribed-tag-ids
+(defn subscribed-tag-ids-for-user
   [conn user-id]
   (d/q '[:find [?tag-id ...]
          :in $ ?user-id

--- a/src/braid/server/db/thread.clj
+++ b/src/braid/server/db/thread.clj
@@ -123,7 +123,7 @@
                     (d/pull-many (d/db conn) thread-pull-pattern thread-eids))
      :remaining (- (count all-thread-eids) (+ skip (count thread-eids)))}))
 
-(defn get-open-threads-for-user
+(defn open-threads-for-user
   [conn user-id]
   (let [visible-tags (tag/tag-ids-for-user conn user-id)]
     (->> (d/q '[:find (pull ?thread pull-pattern)

--- a/src/braid/server/db/thread.clj
+++ b/src/braid/server/db/thread.clj
@@ -29,7 +29,7 @@
   (some-> (d/pull (d/db conn) thread-pull-pattern [:thread/id thread-id])
           db->thread))
 
-(defn get-threads
+(defn threads-by-id
   [conn thread-ids]
   (->> thread-ids
        (map (fn [id] [:thread/id id]))

--- a/src/braid/server/db/thread.clj
+++ b/src/braid/server/db/thread.clj
@@ -153,17 +153,6 @@
        (d/db conn)
        user-id))
 
-(defn get-open-thread-ids-for-user
-  [conn user-id]
-  (d/q '[:find [?thread-id ...]
-         :in $ ?user-id
-         :where
-         [?e :user/id ?user-id]
-         [?e :user/open-thread ?thread]
-         [?thread :thread/id ?thread-id]]
-       (d/db conn)
-       user-id))
-
 (defn user-unsubscribe-from-thread!
   [conn user-id thread-id]
   @(d/transact conn [[:db/retract [:user/id user-id]

--- a/src/braid/server/db/thread.clj
+++ b/src/braid/server/db/thread.clj
@@ -142,7 +142,7 @@
                       db->thread
                       first))))))
 
-(defn get-subscribed-thread-ids-for-user
+(defn subscribed-thread-ids-for-user
   [conn user-id]
   (d/q '[:find [?thread-id ...]
          :in $ ?user-id

--- a/src/braid/server/db/thread.clj
+++ b/src/braid/server/db/thread.clj
@@ -24,7 +24,7 @@
     @(d/transact conn
        [[:db/add [:user/id user-id] :user/open-thread [:thread/id thread-id]]])))
 
-(defn get-thread
+(defn thread-by-id
   [conn thread-id]
   (some-> (d/pull (d/db conn) thread-pull-pattern [:thread/id thread-id])
           db->thread))

--- a/src/braid/server/db/thread.clj
+++ b/src/braid/server/db/thread.clj
@@ -124,7 +124,7 @@
 
 (defn get-open-threads-for-user
   [conn user-id]
-  (let [visible-tags (tag/get-user-visible-tag-ids conn user-id)]
+  (let [visible-tags (tag/tag-ids-for-user conn user-id)]
     (->> (d/q '[:find (pull ?thread pull-pattern)
                 :in $ ?user-id pull-pattern
                 :where

--- a/src/braid/server/db/thread.clj
+++ b/src/braid/server/db/thread.clj
@@ -64,7 +64,7 @@
 (defn thread-add-last-open-at [conn thread user-id]
   (assoc thread :last-open-at (thread-last-open-at conn thread user-id)))
 
-(defn get-users-subscribed-to-thread
+(defn users-subscribed-to-thread
   [conn thread-id]
   (d/q '[:find [?user-id ...]
          :in $ ?thread-id
@@ -81,7 +81,7 @@
     ;user can see the thread if it's a new (i.e. not yet in the database) thread...
     (nil? (d/entity (d/db conn) [:thread/id thread-id]))
     ; ...or they're already subscribed to the thread...
-    (contains? (set (get-users-subscribed-to-thread conn thread-id)) user-id)
+    (contains? (set (users-subscribed-to-thread conn thread-id)) user-id)
     ; ...or they're mentioned in the thread
     ; TODO: is it possible for them to be mentioned but not subscribed?
     (contains? (-> (d/pull (d/db conn) [:thread/mentioned] [:thread/id thread-id])

--- a/src/braid/server/db/thread.clj
+++ b/src/braid/server/db/thread.clj
@@ -9,7 +9,8 @@
                   [:thread/id thread-id])
           :thread/group :group/id))
 
-(defn update-thread-last-open [conn thread-id user-id]
+(defn update-thread-last-open!
+  [conn thread-id user-id]
   (when (seq (d/q '[:find ?t
                     :in $ ?user-id ?thread-id
                     :where

--- a/src/braid/server/db/user.clj
+++ b/src/braid/server/db/user.clj
@@ -140,7 +140,7 @@
        (d/db conn)
        k (pr-str v)))
 
-(defn fetch-users-for-user
+(defn users-for-user
   "Get all users visible to given user"
   [conn user-id]
   (->> (d/q '[:find (pull ?e pull-pattern)

--- a/src/braid/server/db/user.clj
+++ b/src/braid/server/db/user.clj
@@ -36,10 +36,6 @@
   [conn user-id nickname]
   @(d/transact conn [[:db/add [:user/id user-id] :user/nickname nickname]]))
 
-(defn get-nickname
-  [conn user-id]
-  (:user/nickname (d/pull (d/db conn) '[:user/nickname] [:user/id user-id])))
-
 (defn set-user-avatar!
   [conn user-id avatar]
   @(d/transact conn [[:db/add [:user/id user-id] :user/avatar avatar]]))

--- a/src/braid/server/message_format.clj
+++ b/src/braid/server/message_format.clj
@@ -9,7 +9,7 @@
 (defn parse-tags-and-mentions
   [user-id content]
   (let [id->nick (into {} (map (juxt :id :nickname)) (db/users-for-user user-id))
-        id->tag (into {} (map (juxt :id :name)) (db/fetch-tags-for-user user-id))
+        id->tag (into {} (map (juxt :id :name)) (db/tags-for-user user-id))
         uuid-re #"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"
         tag-re (re-pattern (str "#" uuid-re))
         mention-re (re-pattern (str "@" uuid-re))]

--- a/src/braid/server/message_format.clj
+++ b/src/braid/server/message_format.clj
@@ -8,7 +8,7 @@
 
 (defn parse-tags-and-mentions
   [user-id content]
-  (let [id->nick (into {} (map (juxt :id :nickname)) (db/fetch-users-for-user user-id))
+  (let [id->nick (into {} (map (juxt :id :nickname)) (db/users-for-user user-id))
         id->tag (into {} (map (juxt :id :name)) (db/fetch-tags-for-user user-id))
         uuid-re #"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"
         tag-re (re-pattern (str "#" uuid-re))

--- a/src/braid/server/routes/api.clj
+++ b/src/braid/server/routes/api.clj
@@ -93,7 +93,7 @@
         (assoc fail :body "Invalid image")
 
         :else
-        (let [invite (db/get-invite (java.util.UUID/fromString invite_id))]
+        (let [invite (db/invite-by-id (java.util.UUID/fromString invite_id))]
           (if-let [err (:error (invites/verify-invite-nonce invite token))]
             (assoc fail :body "Invalid invite token")
             (let [avatar-url (invites/upload-avatar avatar)

--- a/src/braid/server/routes/client.clj
+++ b/src/braid/server/routes/client.clj
@@ -30,7 +30,7 @@
   ; invite accept page
   (GET "/accept" [invite :<< as-uuid tok]
     (if (and invite tok)
-      (if-let [invite (db/get-invite invite)]
+      (if-let [invite (db/invite-by-id invite)]
         {:status 200 :headers {"Content-Type" "text/html"} :body (invites/register-page invite tok)}
         {:status 400 :headers {"Content-Type" "text/plain"} :body "Invalid invite"})
       {:status 400 :headers {"Content-Type" "text/plain"} :body "Bad invite link, sorry"}))

--- a/src/chat/server/email_digest.clj
+++ b/src/chat/server/email_digest.clj
@@ -38,7 +38,7 @@
 
 (defn updates-for-user-since
   [user-id cutoff]
-  (let [users (db/fetch-users-for-user user-id)
+  (let [users (db/users-for-user user-id)
         id->nick (into {} (map (juxt :id :nickname)) users)
         id->avatar (into {} (map (juxt :id :avatar)) users)
         pretty-time (comp

--- a/src/chat/server/email_digest.clj
+++ b/src/chat/server/email_digest.clj
@@ -66,7 +66,7 @@
                                          (assoc :sender (id->nick sender-id))
                                          (assoc :sender-avatar
                                            (id->avatar sender-id))))))))))
-          (db/get-open-threads-for-user user-id))))
+          (db/open-threads-for-user user-id))))
 
 (defn daily-update-users
   "Find all ids for users that want daily digest updates"

--- a/src/chat/server/invite.clj
+++ b/src/chat/server/invite.clj
@@ -130,7 +130,7 @@
 (defn link-signup-page
   [group-id]
   (let [now (.getTime (java.util.Date.))
-        group (db/get-group group-id)
+        group (db/group-by-id group-id)
         form-hmac (hmac (config :hmac-secret) (str now group-id))
         api-domain (:api-domain config)]
     (clostache/render-resource "templates/link_signup.html.mustache"

--- a/src/chat/server/migrate.clj
+++ b/src/chat/server/migrate.clj
@@ -93,7 +93,7 @@
                               first
                               :message/user)
                   author-grp (some-> author :user/id
-                                     db/get-groups-for-user
+                                     db/user-groups
                                      first :id)
                   fallback-group (:group/id (d/pull (d/db db/conn) [:group/id] [:group/name "Braid"]))]
               (cond
@@ -108,7 +108,7 @@
                 (let [grps (apply
                              set/intersection
                              (map (comp :id
-                                        db/get-groups-for-user
+                                        db/user-groups
                                         :user/id)
                                   (cons author (th :thread/mentioned))))
                       grp (or (first grps) author-grp fallback-group)]

--- a/src/chat/server/sync.clj
+++ b/src/chat/server/sync.clj
@@ -485,7 +485,7 @@
         :version-checksum (digest/from-file "public/js/desktop/out/braid.js")
         :user-groups (db/user-groups user-id)
         :user-threads (db/get-open-threads-for-user user-id)
-        :user-subscribed-tag-ids (db/get-user-subscribed-tag-ids user-id)
+        :user-subscribed-tag-ids (db/subscribed-tag-ids-for-user user-id)
         :user-preferences (db/user-get-preferences user-id)
         :users (into ()
                      (map #(assoc % :status

--- a/src/chat/server/sync.clj
+++ b/src/chat/server/sync.clj
@@ -70,7 +70,7 @@
                                       (set subscribed-user-ids)
                                       (set (:any @connected-uids)))
                                     (set ids-to-skip)))
-          thread (db/get-thread thread-id)]
+          thread (db/thread-by-id thread-id)]
       (doseq [uid user-ids-to-send-to]
         (let [user-tags (db/tag-ids-for-user uid)
               filtered-thread (update-in thread [:tag-ids]
@@ -167,7 +167,7 @@
                       (fn [m] (update m :content
                                       (partial parse-tags-and-mentions uid))))]
                 (-> (email/create-message
-                      [(-> (db/get-thread (msg :thread-id))
+                      [(-> (db/thread-by-id (msg :thread-id))
                            (update :messages update-msgs))])
                     (assoc :subject "Notification from Braid")
                     (->> (email/send-message (db/user-email uid))))))))))))
@@ -329,7 +329,7 @@
     (let [user-tags (db/tag-ids-for-user user-id)
           filter-tags (fn [t] (update-in t [:tag-ids] (partial into #{} (filter user-tags))))
           thread-ids (search/search-threads-as user-id ?data)
-          threads (map (comp filter-tags db/get-thread) (take 25 thread-ids))]
+          threads (map (comp filter-tags db/thread-by-id) (take 25 thread-ids))]
       (when ?reply-fn
         (?reply-fn {:threads threads :thread-ids thread-ids})))))
 

--- a/src/chat/server/sync.clj
+++ b/src/chat/server/sync.clj
@@ -386,7 +386,7 @@
       (db/retract-invitation! (invite :id))
       (chsk-send! user-id [:chat/joined-group
                            {:group (db/group-by-id (invite :group-id))
-                            :tags (db/get-group-tags (invite :group-id))}])
+                            :tags (db/group-tags (invite :group-id))}])
       (chsk-send! user-id [:chat/update-users (db/users-for-user user-id)])
       (broadcast-group-change (invite :group-id) [:group/new-user (db/user-by-id user-id)]))
     (timbre/warnf "User %s attempted to accept nonexistant invitaiton %s"

--- a/src/chat/server/sync.clj
+++ b/src/chat/server/sync.clj
@@ -87,7 +87,7 @@
                            (set (:any @connected-uids))
                            (into
                              #{} (map :id)
-                             (db/fetch-users-for-user user-id)))
+                             (db/users-for-user user-id)))
                          user-id)]
     (doseq [uid ids-to-send-to]
       (chsk-send! uid info))))
@@ -387,7 +387,7 @@
       (chsk-send! user-id [:chat/joined-group
                            {:group (db/get-group (invite :group-id))
                             :tags (db/get-group-tags (invite :group-id))}])
-      (chsk-send! user-id [:chat/update-users (db/fetch-users-for-user user-id)])
+      (chsk-send! user-id [:chat/update-users (db/users-for-user user-id)])
       (broadcast-group-change (invite :group-id) [:group/new-user (db/user-by-id user-id)]))
     (timbre/warnf "User %s attempted to accept nonexistant invitaiton %s"
                   user-id (?data :id))))
@@ -490,6 +490,6 @@
         :users (into ()
                      (map #(assoc % :status
                              (if (connected (% :id)) :online :offline)))
-                     (db/fetch-users-for-user user-id))
+                     (db/users-for-user user-id))
         :invitations (db/fetch-invitations-for-user user-id)
         :tags (db/fetch-tags-for-user user-id)}])))

--- a/src/chat/server/sync.clj
+++ b/src/chat/server/sync.clj
@@ -338,7 +338,7 @@
   (let [user-tags (db/tag-ids-for-user user-id)
         filter-tags (fn [t] (update-in t [:tag-ids] (partial into #{} (filter user-tags))))
         thread-ids (filter (partial db/user-can-see-thread? user-id) ?data)
-        threads (map filter-tags (db/get-threads thread-ids))]
+        threads (map filter-tags (db/threads-by-id thread-ids))]
     (when ?reply-fn
       (?reply-fn {:threads threads}))))
 

--- a/src/chat/server/sync.clj
+++ b/src/chat/server/sync.clj
@@ -484,7 +484,7 @@
        {:user-id user-id
         :version-checksum (digest/from-file "public/js/desktop/out/braid.js")
         :user-groups (db/user-groups user-id)
-        :user-threads (db/get-open-threads-for-user user-id)
+        :user-threads (db/open-threads-for-user user-id)
         :user-subscribed-tag-ids (db/subscribed-tag-ids-for-user user-id)
         :user-preferences (db/user-get-preferences user-id)
         :users (into ()

--- a/src/chat/server/sync.clj
+++ b/src/chat/server/sync.clj
@@ -64,7 +64,7 @@
 (defn broadcast-thread
   "broadcasts thread to all subscribed users, except those in ids-to-skip"
   [thread-id ids-to-skip]
-  (let [subscribed-user-ids (db/get-users-subscribed-to-thread thread-id)
+  (let [subscribed-user-ids (db/users-subscribed-to-thread thread-id)
           user-ids-to-send-to (-> (difference
                                     (intersection
                                       (set subscribed-user-ids)
@@ -148,7 +148,7 @@
 
 (defn notify-users [new-message]
   (let [subscribed-user-ids (->>
-                              (db/get-users-subscribed-to-thread
+                              (db/users-subscribed-to-thread
                                 (new-message :thread-id))
                               (remove (partial = (:user-id new-message))))
         online? (intersection

--- a/src/chat/server/sync.clj
+++ b/src/chat/server/sync.clj
@@ -492,4 +492,4 @@
                              (if (connected (% :id)) :online :offline)))
                      (db/users-for-user user-id))
         :invitations (db/invites-for-user user-id)
-        :tags (db/fetch-tags-for-user user-id)}])))
+        :tags (db/tags-for-user user-id)}])))

--- a/src/chat/server/sync.clj
+++ b/src/chat/server/sync.clj
@@ -491,5 +491,5 @@
                      (map #(assoc % :status
                              (if (connected (% :id)) :online :offline)))
                      (db/users-for-user user-id))
-        :invitations (db/fetch-invitations-for-user user-id)
+        :invitations (db/invites-for-user user-id)
         :tags (db/fetch-tags-for-user user-id)}])))

--- a/src/chat/server/sync.clj
+++ b/src/chat/server/sync.clj
@@ -385,7 +385,7 @@
       (db/user-subscribe-to-group-tags! user-id (invite :group-id))
       (db/retract-invitation! (invite :id))
       (chsk-send! user-id [:chat/joined-group
-                           {:group (db/get-group (invite :group-id))
+                           {:group (db/group-by-id (invite :group-id))
                             :tags (db/get-group-tags (invite :group-id))}])
       (chsk-send! user-id [:chat/update-users (db/users-for-user user-id)])
       (broadcast-group-change (invite :group-id) [:group/new-user (db/user-by-id user-id)]))
@@ -419,7 +419,7 @@
                                         [group-id to-remove-id]])
       (chsk-send!
         to-remove-id
-        [:user/left-group [group-id (:name (db/get-group group-id))]]))))
+        [:user/left-group [group-id (:name (db/group-by-id group-id))]]))))
 
 (defmethod event-msg-handler :chat/set-group-intro
   [{:as ev-msg :keys [event id ?data ring-req ?reply-fn send-fn user-id]}]

--- a/src/chat/server/sync.clj
+++ b/src/chat/server/sync.clj
@@ -483,7 +483,7 @@
       [:session/init-data
        {:user-id user-id
         :version-checksum (digest/from-file "public/js/desktop/out/braid.js")
-        :user-groups (db/get-groups-for-user user-id)
+        :user-groups (db/user-groups user-id)
         :user-threads (db/get-open-threads-for-user user-id)
         :user-subscribed-tag-ids (db/get-user-subscribed-tag-ids user-id)
         :user-preferences (db/user-get-preferences user-id)

--- a/src/chat/server/sync.clj
+++ b/src/chat/server/sync.clj
@@ -98,7 +98,7 @@
   (let [ids-to-send-to (intersection
                          (set (:any @connected-uids))
                          (into #{} (map :id)
-                               (db/get-users-in-group group-id)))]
+                               (db/group-users group-id)))]
     (doseq [uid ids-to-send-to]
       (chsk-send! uid info))))
 
@@ -277,7 +277,7 @@
     (if (valid-tag-name? (?data :name))
       (let [new-tag (db/create-tag! (select-keys ?data [:id :name :group-id]))
             connected? (set (:any @connected-uids))]
-        (doseq [u (db/get-users-in-group (:group-id new-tag))]
+        (doseq [u (db/group-users (:group-id new-tag))]
           (db/user-subscribe-to-tag! (u :id) (new-tag :id))
           (when (and (not= user-id (u :id)) (connected? (u :id)))
             (chsk-send! (u :id) [:chat/create-tag new-tag])))

--- a/src/chat/server/sync.clj
+++ b/src/chat/server/sync.clj
@@ -379,7 +379,7 @@
 
 (defmethod event-msg-handler :chat/invitation-accept
   [{:as ev-msg :keys [event id ?data ring-req ?reply-fn send-fn user-id]}]
-  (if-let [invite (db/get-invite (?data :id))]
+  (if-let [invite (db/invite-by-id (?data :id))]
     (do
       (db/user-add-to-group! user-id (invite :group-id))
       (db/user-subscribe-to-group-tags! user-id (invite :group-id))
@@ -394,7 +394,7 @@
 
 (defmethod event-msg-handler :chat/invitation-decline
   [{:as ev-msg :keys [event id ?data ring-req ?reply-fn send-fn user-id]}]
-  (if-let [invite (db/get-invite (?data :id))]
+  (if-let [invite (db/invite-by-id (?data :id))]
     (db/retract-invitation! (invite :id))
     (timbre/warnf "User %s attempted to decline nonexistant invitaiton %s"
                   user-id (?data :id))))

--- a/src/chat/server/sync.clj
+++ b/src/chat/server/sync.clj
@@ -269,7 +269,7 @@
 
 (defmethod event-msg-handler :chat/mark-thread-read
   [{:as ev-msg :keys [ring-req ?data user-id]}]
-  (db/update-thread-last-open ?data user-id))
+  (db/update-thread-last-open! ?data user-id))
 
 (defmethod event-msg-handler :chat/create-tag
   [{:as ev-msg :keys [event id ?data ring-req ?reply-fn send-fn user-id]}]

--- a/test/chat/test/server/db.clj
+++ b/test/chat/test/server/db.clj
@@ -73,7 +73,7 @@
         group (db/create-group! {:id (db/uuid) :name "aoeu"})
         _ (db/user-add-to-group! (user-1 :id) (group :id))
         _ (db/user-add-to-group! (user-2 :id) (group :id))
-        users (db/fetch-users-for-user (user-1 :id))]
+        users (db/users-for-user (user-1 :id))]
     (testing "returns all users"
       (is (= (set (map (fn [u] (dissoc u :group-ids)) users))
              (set (map (fn [u] (dissoc u :group-ids)) [user-1 user-2])))))
@@ -107,15 +107,15 @@
     (is (= (set (map (fn [u] (dissoc u :group-ids))
                      [user-1 user-2]))
            (set (map (fn [u] (dissoc u :group-ids))
-                (db/fetch-users-for-user (user-1 :id))))))
+                (db/users-for-user (user-1 :id))))))
     (is (= (set (map (fn [u] (dissoc u :group-ids))
                      [user-1 user-2 user-3]))
            (set (map (fn [u] (dissoc u :group-ids))
-                (db/fetch-users-for-user (user-2 :id))))))
+                (db/users-for-user (user-2 :id))))))
     (is (= (set (map (fn [u] (dissoc u :group-ids))
                      [user-2 user-3]))
            (set (map (fn [u] (dissoc u :group-ids))
-                (db/fetch-users-for-user (user-3 :id))))))
+                (db/users-for-user (user-3 :id))))))
     (is (db/user-visible-to-user? (user-1 :id) (user-2 :id)))
     (is (not (db/user-visible-to-user? (user-1 :id) (user-3 :id))))
     (is (not (db/user-visible-to-user? (user-3 :id) (user-1 :id))))

--- a/test/chat/test/server/db.clj
+++ b/test/chat/test/server/db.clj
@@ -155,7 +155,7 @@
                      :public? false :bots #{}))))
     (testing "can set group intro"
       (db/group-set! (group :id) :intro "the intro")
-      (is (= (db/get-group (group :id))
+      (is (= (db/group-by-id (group :id))
              (assoc data :admins #{} :intro "the intro" :avatar nil
                :public? false :bots #{}))))
     (testing "can add a user to the group"
@@ -173,17 +173,17 @@
                (set (map (fn [u] (dissoc user :group-ids))
                     (db/get-users-in-group (group :id))))))))
     (testing "groups have no admins by default"
-      (is (empty? (:admins (db/get-group (group :id))))))
+      (is (empty? (:admins (db/group-by-id (group :id))))))
     (testing "Can add admin"
       (db/user-make-group-admin! user-id (group :id))
-      (is (= #{user-id} (:admins (db/get-group (group :id)))))
+      (is (= #{user-id} (:admins (db/group-by-id (group :id)))))
       (testing "and another admin"
         (db/create-user! {:id user-2-id
                           :email "bar@baz.com"
                           :password "foobar"
                           :avatar "http://www.foobar.com/1.jpg"})
         (db/user-make-group-admin! user-2-id (group :id))
-        (is (= #{user-id user-2-id} (:admins (db/get-group (group :id)))))))
+        (is (= #{user-id user-2-id} (:admins (db/group-by-id (group :id)))))))
     (testing "multiple groups, admin statuses"
       (let [group-2 (db/create-group! {:id (db/uuid)
                                        :name "another group"})
@@ -207,8 +207,8 @@
                (into #{} (map :id) (db/get-groups-for-user user-2-id)))
             "Both users are in all the groups")
 
-        (is (= #{user-2-id} (:admins (db/get-group (group-2 :id)))))
-        (is (= #{user-id} (:admins (db/get-group (group-3 :id)))))
+        (is (= #{user-2-id} (:admins (db/group-by-id (group-2 :id)))))
+        (is (= #{user-id} (:admins (db/group-by-id (group-3 :id)))))
 
         (is (db/user-is-group-admin? user-id (group :id)))
         (is (not (db/user-is-group-admin? user-id (group-2 :id))))
@@ -450,7 +450,7 @@
                            {:id (db/uuid) :name "t2" :group-id (group :id)}
                            {:id (db/uuid) :name "t3" :group-id (group :id)}]))]
     (testing "some misc functions"
-      (is (= group (db/get-group (group :id))))
+      (is (= group (db/group-by-id (group :id))))
       (is (= (set group-tags)
              (set (db/get-group-tags (group :id))))))
     (db/user-add-to-group! (user :id) (group :id))
@@ -524,7 +524,7 @@
     (is (schema/check-bot! b3))
     (testing "can create bots & retrieve by group"
       (is (= #{b1 b2} (db/bots-in-group (g1 :id))))
-      (is (= (into #{}  (map bot->display) [b1 b2]) (:bots (db/get-group (g1 :id)))))
+      (is (= (into #{}  (map bot->display) [b1 b2]) (:bots (db/group-by-id (g1 :id)))))
       (is (= #{b3} (db/bots-in-group (g2 :id))))
       (is (= #{} (db/bots-in-group (g3 :id))))
       (is (= b1 (db/bot-by-name-in-group "bot1" (g1 :id))))

--- a/test/chat/test/server/db.clj
+++ b/test/chat/test/server/db.clj
@@ -164,14 +164,14 @@
                                    :password "foobar"
                                    :avatar "http://www.foobar.com/1.jpg"})]
         (is (= #{} (db/get-groups-for-user (user :id))))
-        (is (= #{} (db/get-users-in-group (group :id))))
+        (is (= #{} (db/group-users (group :id))))
         (db/user-add-to-group! (user :id) (group :id))
         (is (= #{(assoc data :admins #{} :intro "the intro" :avatar nil
                    :public? false :bots #{})}
                (db/get-groups-for-user (user :id))))
         (is (= #{(dissoc user :group-ids)}
                (set (map (fn [u] (dissoc user :group-ids))
-                    (db/get-users-in-group (group :id))))))))
+                    (db/group-users (group :id))))))))
     (testing "groups have no admins by default"
       (is (empty? (:admins (db/group-by-id (group :id))))))
     (testing "Can add admin"

--- a/test/chat/test/server/db.clj
+++ b/test/chat/test/server/db.clj
@@ -259,7 +259,7 @@
                             :created-at (java.util.Date.)
                             :content "Blurrp"}
             message-3 (db/create-message! message-3-data)]
-        (is (= (db/get-threads [thread-1-id thread-2-id])
+        (is (= (db/threads-by-id [thread-1-id thread-2-id])
                [{:id thread-1-id
                  :group-id (group :id)
                  :messages (map #(dissoc % :thread-id :group-id)

--- a/test/chat/test/server/db.clj
+++ b/test/chat/test/server/db.clj
@@ -245,7 +245,7 @@
     (testing "fetch-messages returns all messages"
       (is (= (set messages) #{message-1 message-2})))
     (testing "Can retrieve threads"
-      (is (= (db/get-thread thread-1-id)
+      (is (= (db/thread-by-id thread-1-id)
              {:id thread-1-id
               :group-id (group :id)
               :messages (map #(dissoc % :thread-id :group-id)
@@ -434,9 +434,9 @@
                          :mentioned-tag-ids []})
     (testing "user leaving group removes mentios of that user"
       (is (= #{(user-1 :id)}
-             (:mentioned-ids (db/get-thread thread-id))))
+             (:mentioned-ids (db/thread-by-id thread-id))))
       (db/user-leave-group! (user-1 :id) (group :id))
-      (is (empty? (:mentioned-ids (db/get-thread thread-id)))))))
+      (is (empty? (:mentioned-ids (db/thread-by-id thread-id)))))))
 
 (deftest adding-user-to-group-subscribes-tags
   (let [user (db/create-user! {:id (db/uuid)

--- a/test/chat/test/server/db.clj
+++ b/test/chat/test/server/db.clj
@@ -407,17 +407,17 @@
                                  :avatar ""})
         group (db/create-group! {:name "group 1" :id (db/uuid)})]
     (db/user-add-to-group! (user-1 :id) (group :id))
-    (is (empty? (db/fetch-invitations-for-user (user-1 :id))))
-    (is (empty? (db/fetch-invitations-for-user (user-2 :id))))
+    (is (empty? (db/invites-for-user (user-1 :id))))
+    (is (empty? (db/invites-for-user (user-2 :id))))
     (let [invite-id (db/uuid)
           invite (db/create-invitation! {:id invite-id
                                          :inviter-id (user-1 :id)
                                          :invitee-email "bar@baz.com"
                                          :group-id (group :id)})]
       (is (= invite (db/invite-by-id invite-id)))
-      (is (seq (db/fetch-invitations-for-user (user-2 :id))))
+      (is (seq (db/invites-for-user (user-2 :id))))
       (db/retract-invitation! invite-id)
-      (is (empty? (db/fetch-invitations-for-user (user-2 :id)))))))
+      (is (empty? (db/invites-for-user (user-2 :id)))))))
 
 (deftest user-leaving-group
   (let [user-1 (db/create-user! {:id (db/uuid)

--- a/test/chat/test/server/db.clj
+++ b/test/chat/test/server/db.clj
@@ -455,7 +455,7 @@
              (set (db/group-tags (group :id))))))
     (db/user-add-to-group! (user :id) (group :id))
     (db/user-subscribe-to-group-tags! (user :id) (group :id))
-    (is (= (set (db/get-user-subscribed-tag-ids (user :id)))
+    (is (= (set (db/subscribed-tag-ids-for-user (user :id)))
            (db/tag-ids-for-user (user :id))
            (set (map :id group-tags))))))
 

--- a/test/chat/test/server/db.clj
+++ b/test/chat/test/server/db.clj
@@ -414,7 +414,7 @@
                                          :inviter-id (user-1 :id)
                                          :invitee-email "bar@baz.com"
                                          :group-id (group :id)})]
-      (is (= invite (db/get-invite invite-id)))
+      (is (= invite (db/invite-by-id invite-id)))
       (is (seq (db/fetch-invitations-for-user (user-2 :id))))
       (db/retract-invitation! invite-id)
       (is (empty? (db/fetch-invitations-for-user (user-2 :id)))))))

--- a/test/chat/test/server/db.clj
+++ b/test/chat/test/server/db.clj
@@ -456,7 +456,7 @@
     (db/user-add-to-group! (user :id) (group :id))
     (db/user-subscribe-to-group-tags! (user :id) (group :id))
     (is (= (set (db/get-user-subscribed-tag-ids (user :id)))
-           (db/get-user-visible-tag-ids (user :id))
+           (db/tag-ids-for-user (user :id))
            (set (map :id group-tags))))))
 
 (deftest user-preferences

--- a/test/chat/test/server/db.clj
+++ b/test/chat/test/server/db.clj
@@ -163,12 +163,12 @@
                                    :email "foo@bar.com"
                                    :password "foobar"
                                    :avatar "http://www.foobar.com/1.jpg"})]
-        (is (= #{} (db/get-groups-for-user (user :id))))
+        (is (= #{} (db/user-groups (user :id))))
         (is (= #{} (db/group-users (group :id))))
         (db/user-add-to-group! (user :id) (group :id))
         (is (= #{(assoc data :admins #{} :intro "the intro" :avatar nil
                    :public? false :bots #{})}
-               (db/get-groups-for-user (user :id))))
+               (db/user-groups (user :id))))
         (is (= #{(dissoc user :group-ids)}
                (set (map (fn [u] (dissoc user :group-ids))
                     (db/group-users (group :id))))))))
@@ -203,8 +203,8 @@
         (is (db/user-in-group? user-2-id (group-3 :id)))
 
         (is (= #{(group :id) (group-2 :id) (group-3 :id)}
-               (into #{} (map :id) (db/get-groups-for-user user-id))
-               (into #{} (map :id) (db/get-groups-for-user user-2-id)))
+               (into #{} (map :id) (db/user-groups user-id))
+               (into #{} (map :id) (db/user-groups user-2-id)))
             "Both users are in all the groups")
 
         (is (= #{user-2-id} (:admins (db/group-by-id (group-2 :id)))))

--- a/test/chat/test/server/db.clj
+++ b/test/chat/test/server/db.clj
@@ -452,7 +452,7 @@
     (testing "some misc functions"
       (is (= group (db/group-by-id (group :id))))
       (is (= (set group-tags)
-             (set (db/get-group-tags (group :id))))))
+             (set (db/group-tags (group :id))))))
     (db/user-add-to-group! (user :id) (group :id))
     (db/user-subscribe-to-group-tags! (user :id) (group :id))
     (is (= (set (db/get-user-subscribed-tag-ids (user :id)))

--- a/test/chat/test/server/db.clj
+++ b/test/chat/test/server/db.clj
@@ -296,15 +296,16 @@
                                        :created-at (java.util.Date.)
                                        :content "Hello?"})]
     (testing "thread 1 is open"
-      (is (contains? (set (db/get-open-thread-ids-for-user (user-1 :id))) (message-1 :thread-id))))
+      (is (contains? (set (map :id (db/open-threads-for-user (user-1 :id))))
+                     (message-1 :thread-id))))
     (testing "thread 2 is open"
-      (is (contains? (set (db/get-open-thread-ids-for-user (user-1 :id))) (message-2 :thread-id))))
+      (is (contains? (set (map :id (db/open-threads-for-user (user-1 :id)))) (message-2 :thread-id))))
     (testing "user can hide thread"
       (db/user-hide-thread! (user-1 :id) (message-1 :thread-id))
-      (is (not (contains? (set (db/get-open-thread-ids-for-user (user-1 :id))) (message-1 :thread-id)))))
+      (is (not (contains? (set (map :id (db/open-threads-for-user (user-1 :id)))) (message-1 :thread-id)))))
     (testing "user can hide thread"
       (db/user-hide-thread! (user-1 :id) (message-2 :thread-id))
-      (is (not (contains? (set (db/get-open-thread-ids-for-user (user-1 :id))) (message-2 :thread-id)))))
+      (is (not (contains? (set (map :id (db/open-threads-for-user (user-1 :id)))) (message-2 :thread-id)))))
     (testing "thread is re-opened when it gets another message"
       (let [user-2 (db/create-user! {:id (db/uuid) :email "bar@baz.com"
                                      :password "foobar" :avatar ""})]
@@ -314,7 +315,7 @@
                              :thread-id (message-1 :thread-id)
                              :created-at (java.util.Date.)
                              :content "wake up"})
-        (is (contains? (set (db/get-open-thread-ids-for-user (user-1 :id))) (message-1 :thread-id)))
+        (is (contains? (set (map :id (db/open-threads-for-user (user-1 :id)))) (message-1 :thread-id)))
         (testing "unless the user has unsubscribed from the thread"
           (db/user-unsubscribe-from-thread! (user-1 :id) (message-2 :thread-id))
           (db/create-message! {:id (db/uuid)
@@ -323,7 +324,7 @@
                                :thread-id (message-2 :thread-id)
                                :created-at (java.util.Date.)
                                :content "wake up"})
-          (is (not (contains? (set (db/get-open-thread-ids-for-user (user-1 :id))) (message-2 :thread-id))))
+          (is (not (contains? (set (map :id (db/open-threads-for-user (user-1 :id)))) (message-2 :thread-id))))
           (testing "but they get re-subscribed if they get mentioned/another tag is added"
             (db/create-message! {:id (db/uuid)
                                  :group-id (group :id)
@@ -332,7 +333,7 @@
                                  :created-at (java.util.Date.)
                                  :content "wake up"
                                  :mentioned-user-ids [(user-1 :id)]})
-            (is (contains? (set (db/get-open-thread-ids-for-user (user-1 :id))) (message-2 :thread-id)))))))))
+            (is (contains? (set (map :id (db/open-threads-for-user (user-1 :id)))) (message-2 :thread-id)))))))))
 
 (deftest user-thread-visibility
   (let [user-1 (db/create-user! {:id (db/uuid)

--- a/test/chat/test/server/db.clj
+++ b/test/chat/test/server/db.clj
@@ -42,8 +42,7 @@
                  (dissoc :group-ids))
              (-> data
                  (dissoc :password :email)
-                 (assoc :nickname "ol' fooy"))))
-      (is (= "ol' fooy" (db/get-nickname (user :id)))))
+                 (assoc :nickname "ol' fooy")))))
 
     (testing "user email must be unique"
       (is (thrown? java.util.concurrent.ExecutionException

--- a/test/chat/test/server/new_message.clj
+++ b/test/chat/test/server/new_message.clj
@@ -40,7 +40,7 @@
           (is (contains? (set (db/get-open-thread-ids-for-user (user-1 :id))) thread-id)))
 
         (testing "user has thread subscribed"
-          (is (contains? (set (db/get-subscribed-thread-ids-for-user (user-1 :id))) thread-id)))))
+          (is (contains? (set (db/subscribed-thread-ids-for-user (user-1 :id))) thread-id)))))
 
     (testing "new message can add to an existing thread"
       (let [group (db/create-group! {:id (db/uuid) :name "group2"})
@@ -59,7 +59,7 @@
           (is (contains? (set (db/get-open-thread-ids-for-user (user-1 :id))) thread-id)))
 
         (testing "user has thread subscribed"
-          (is (contains? (set (db/get-subscribed-thread-ids-for-user (user-1 :id))) thread-id)))))))
+          (is (contains? (set (db/subscribed-thread-ids-for-user (user-1 :id))) thread-id)))))))
 
 (deftest new-message-opens-and-subscribes
 
@@ -83,7 +83,7 @@
             (is (contains? (set (db/get-open-thread-ids-for-user (user-1 :id))) thread-id)))
 
           (testing "then the user has the thread open"
-            (is (contains? (set (db/get-subscribed-thread-ids-for-user (user-1 :id))) thread-id))))))))
+            (is (contains? (set (db/subscribed-thread-ids-for-user (user-1 :id))) thread-id))))))))
 
 (deftest new-message-opens-thread
 
@@ -166,7 +166,7 @@
                 (is (contains? (set user-threads) (msg :thread-id)))))
 
             (testing "then the user is subscribed-to the thread"
-              (let [user-threads (db/get-subscribed-thread-ids-for-user (user-1 :id))]
+              (let [user-threads (db/subscribed-thread-ids-for-user (user-1 :id))]
                 (is (contains? (set user-threads) (msg :thread-id))))
               (let [users (db/users-subscribed-to-thread (msg :thread-id))]
                 (is (contains? (set users) (user-1 :id)))))))))))

--- a/test/chat/test/server/new_message.clj
+++ b/test/chat/test/server/new_message.clj
@@ -158,7 +158,7 @@
                                          :mentioned-tag-ids [(tag-1 :id)]})]
 
             (testing "then the tag is added to the thread"
-              (let [thread (db/get-thread (msg :thread-id))]
+              (let [thread (db/thread-by-id (msg :thread-id))]
                 (contains? (set (thread :tag-ids)) (tag-1 :id))))
 
             (testing "then the user has the thread opened"
@@ -199,7 +199,7 @@
 
           (testing "then user-2 is added to the thread"
             (is  (= #{(user-2 :id)}
-                    (-> (db/get-thread thread-id) :mentioned-ids))))
+                    (-> (db/thread-by-id thread-id) :mentioned-ids))))
 
           (testing "then user-2 can see the thread"
             (is (db/user-can-see-thread? (user-2 :id) thread-id)))

--- a/test/chat/test/server/new_message.clj
+++ b/test/chat/test/server/new_message.clj
@@ -168,7 +168,7 @@
             (testing "then the user is subscribed-to the thread"
               (let [user-threads (db/get-subscribed-thread-ids-for-user (user-1 :id))]
                 (is (contains? (set user-threads) (msg :thread-id))))
-              (let [users (db/get-users-subscribed-to-thread (msg :thread-id))]
+              (let [users (db/users-subscribed-to-thread (msg :thread-id))]
                 (is (contains? (set users) (user-1 :id)))))))))))
 
 (deftest user-mention-subscribes-opens-thread-for-user
@@ -205,7 +205,7 @@
             (is (db/user-can-see-thread? (user-2 :id) thread-id)))
 
           (testing "then user-2 is subscribed to the thread"
-            (let [users (db/get-users-subscribed-to-thread (msg :thread-id))]
+            (let [users (db/users-subscribed-to-thread (msg :thread-id))]
               (is (contains? (set users) (user-2 :id)))))
 
           (testing "then user-2 has the thread opened"

--- a/test/chat/test/server/new_message.clj
+++ b/test/chat/test/server/new_message.clj
@@ -37,7 +37,7 @@
           (is (= (dissoc message-data :group-id) message)))
 
         (testing "user has thread open"
-          (is (contains? (set (db/get-open-thread-ids-for-user (user-1 :id))) thread-id)))
+          (is (contains? (set (map :id (db/open-threads-for-user (user-1 :id)))) thread-id)))
 
         (testing "user has thread subscribed"
           (is (contains? (set (db/subscribed-thread-ids-for-user (user-1 :id))) thread-id)))))
@@ -56,7 +56,7 @@
           (is (= (dissoc message-2-data :group-id) message-2)))
 
         (testing "user has thread open"
-          (is (contains? (set (db/get-open-thread-ids-for-user (user-1 :id))) thread-id)))
+          (is (contains? (set (map :id (db/open-threads-for-user (user-1 :id)))) thread-id)))
 
         (testing "user has thread subscribed"
           (is (contains? (set (db/subscribed-thread-ids-for-user (user-1 :id))) thread-id)))))))
@@ -80,7 +80,7 @@
                                      :content "Hello?"})]
 
           (testing "then the user is subscribed to the thread"
-            (is (contains? (set (db/get-open-thread-ids-for-user (user-1 :id))) thread-id)))
+            (is (contains? (set (map :id (db/open-threads-for-user (user-1 :id)))) thread-id)))
 
           (testing "then the user has the thread open"
             (is (contains? (set (db/subscribed-thread-ids-for-user (user-1 :id))) thread-id))))))))
@@ -115,7 +115,7 @@
         (db/user-hide-thread! (user-2 :id) thread-id)
 
         (testing "then user-2 no longer has the thread open"
-          (is (not (contains? (set (db/get-open-thread-ids-for-user (user-2 :id))) thread-id)))))
+          (is (not (contains? (set (map :id (db/open-threads-for-user (user-2 :id)))) thread-id)))))
 
       (testing "when user-1 sends another message in the thread"
         (db/create-message! {:id (db/uuid)
@@ -126,7 +126,7 @@
                              :content "Hello?"})
 
         (testing "then user-2 has the thread open again"
-          (is (contains? (set (db/get-open-thread-ids-for-user (user-2 :id))) thread-id)))))))
+          (is (contains? (set (map :id (db/open-threads-for-user (user-2 :id)))) thread-id)))))))
 
 (deftest tag-mention-opens-thread-for-subscribers
 
@@ -162,7 +162,7 @@
                 (contains? (set (thread :tag-ids)) (tag-1 :id))))
 
             (testing "then the user has the thread opened"
-              (let [user-threads (db/get-open-thread-ids-for-user (user-1 :id))]
+              (let [user-threads (map :id (db/open-threads-for-user (user-1 :id)))]
                 (is (contains? (set user-threads) (msg :thread-id)))))
 
             (testing "then the user is subscribed-to the thread"
@@ -209,4 +209,4 @@
               (is (contains? (set users) (user-2 :id)))))
 
           (testing "then user-2 has the thread opened"
-            (is (= [thread-id] (db/get-open-thread-ids-for-user (user-2 :id))))))))))
+            (is (= [thread-id] (map :id (db/open-threads-for-user (user-2 :id)))))))))))

--- a/test/chat/test/server/tags.clj
+++ b/test/chat/test/server/tags.clj
@@ -33,7 +33,7 @@
                          :subscribers-count 0))))))
       (testing "set tag description"
         (db/tag-set-description! (:id tag-data) "Some tag with stuff")
-        (is (= (first (db/get-group-tags (:id group)))
+        (is (= (first (db/group-tags (:id group)))
                (assoc tag-data
                  :description "Some tag with stuff"
                  :group-name "Lean Pixel"

--- a/test/chat/test/server/tags.clj
+++ b/test/chat/test/server/tags.clj
@@ -92,9 +92,9 @@
     (db/user-add-to-group! (user-2 :id) (group-2 :id))
     (db/user-add-to-group! (user-3 :id) (group-2 :id))
     (testing "user can only see tags in their group(s)"
-      (is (= #{tag-1} (db/fetch-tags-for-user (user-1 :id))))
-      (is (= #{tag-1 tag-2 tag-3} (db/fetch-tags-for-user (user-2 :id))))
-      (is (= #{tag-2 tag-3} (db/fetch-tags-for-user (user-3 :id)))))))
+      (is (= #{tag-1} (db/tags-for-user (user-1 :id))))
+      (is (= #{tag-1 tag-2 tag-3} (db/tags-for-user (user-2 :id))))
+      (is (= #{tag-2 tag-3} (db/tags-for-user (user-3 :id)))))))
 
 (deftest user-can-only-subscribe-to-tags-in-group
   (let [user (db/create-user! {:id (db/uuid)

--- a/test/chat/test/server/tags.clj
+++ b/test/chat/test/server/tags.clj
@@ -56,7 +56,7 @@
         (db/user-subscribe-to-tag! (user :id) (tag-1 :id))
         (db/user-subscribe-to-tag! (user :id) (tag-2 :id)))
       (testing "get-user-subscribed-tags"
-        (let [tags (db/get-user-subscribed-tag-ids (user :id))]
+        (let [tags (db/subscribed-tag-ids-for-user (user :id))]
           (testing "returns subscribed tags"
             (is (= (set tags) #{(tag-1 :id) (tag-2 :id)}))))))
     (testing "user can unsubscribe from tags"
@@ -64,7 +64,7 @@
         (db/user-unsubscribe-from-tag! (user :id) (tag-1 :id))
         (db/user-unsubscribe-from-tag! (user :id) (tag-2 :id)))
       (testing "is unsubscribed"
-        (let [tags (db/get-user-subscribed-tag-ids (user :id))]
+        (let [tags (db/subscribed-tag-ids-for-user (user :id))]
           (is (= (set tags) #{})))))))
 
 (deftest user-can-only-see-tags-in-group
@@ -113,6 +113,6 @@
         (db/user-subscribe-to-tag! (user :id) (tag-1 :id))
         (db/user-subscribe-to-tag! (user :id) (tag-2 :id)))
       (testing "get-user-subscribed-tags"
-        (let [tags (db/get-user-subscribed-tag-ids (user :id))]
+        (let [tags (db/subscribed-tag-ids-for-user (user :id))]
           (testing "returns subscribed tags"
             (is (= (set tags) #{(tag-1 :id)}))))))))


### PR DESCRIPTION
Make the naming convention for db names more idiomatic - mainly replace `get-*` and `fetch-*` fns with just `*` (so they are nouns rather than verbs)