### PR TITLE
First class uploads

### DIFF
--- a/src/braid/common/schema.cljc
+++ b/src/braid/common/schema.cljc
@@ -115,7 +115,8 @@
 (def Upload
   {:id s/Uuid
    :thread-id s/Uuid
-   (s/optional-key :uploaded-at) s/Inst
+   :uploader-id s/Uuid
+   :uploaded-at s/Inst
    :url s/Str})
 (def check-upload! (s/validator Upload))
 (defn upload-valid? [upload]

--- a/src/braid/common/schema.cljc
+++ b/src/braid/common/schema.cljc
@@ -111,3 +111,15 @@
    :invitee-email s/Str
    :group-id s/Uuid
    :group-name s/Str})
+
+(def Upload
+  {:id s/Uuid
+   :thread-id s/Uuid
+   (s/optional-key :uploaded-at) s/Inst
+   :url s/Str})
+(def check-upload! (s/validator Upload))
+(defn upload-valid? [upload]
+  (try (check-upload! upload) true
+    (catch ExceptionInfo e
+      (debugf "Bad upload format: %s" (:error (ex-data e)))
+      false)))

--- a/src/braid/common/state.cljs
+++ b/src/braid/common/state.cljs
@@ -95,6 +95,11 @@
   [state _]
   (reaction (@state :page)))
 
+(defn get-thread
+  ([state [_ thread-id]] (get-thread state nil [thread-id]))
+  ([state _ [thread-id]]
+   (reaction (get-in @state [:threads thread-id]))))
+
 (defn get-threads
   [state _]
   (reaction (@state :threads)))

--- a/src/braid/server/db/common.clj
+++ b/src/braid/server/db/common.clj
@@ -144,10 +144,12 @@
   [:upload/id
    :upload/url
    :upload/uploaded-at
-   {:upload/thread [:thread/id]}])
+   {:upload/thread [:thread/id]}
+   {:upload/uploaded-by [:user/id]}])
 
 (defn db->upload [e]
   {:id (:upload/id e)
    :uploaded-at (:upload/uploaded-at e)
    :thread-id (get-in e [:upload/thread :thread/id])
+   :uploader-id (get-in e [:upload/uploaded-by :user/id])
    :url (:upload/url e)})

--- a/src/braid/server/db/common.clj
+++ b/src/braid/server/db/common.clj
@@ -128,7 +128,6 @@
    :group/name
    :group/settings
    {:group/admins [:user/id]}
-   ; delibrately not using bot-pull-pattern here - just want display info
    {:bot/_group bot-display-pull-pattern}])
 
 (defn db->group [e]
@@ -140,3 +139,15 @@
      :avatar (settings :avatar)
      :public? (get settings :public? false)
      :bots (into #{} (map db->bot-display) (:bot/_group e))}))
+
+(def upload-pull-pattern
+  [:upload/id
+   :upload/url
+   :upload/uploaded-at
+   {:upload/thread [:thread/id]}])
+
+(defn db->upload [e]
+  {:id (:upload/id e)
+   :uploaded-at (:upload/uploaded-at e)
+   :thread-id (get-in e [:upload/thread :thread/id])
+   :url (:upload/url e)})

--- a/src/braid/server/db/upload.clj
+++ b/src/braid/server/db/upload.clj
@@ -1,0 +1,24 @@
+(ns braid.server.db.upload
+  (:require [datomic.api :as d]
+            [braid.server.db.common :refer :all]))
+
+(defn create-upload!
+  [conn {:keys [id url thread-id]}]
+  (->> {:upload/id id
+        :upload/url url
+        :upload/thread [:thread/id thread-id]
+        :upload/uploaded-at (java.util.Date.)}
+       (create-entity! conn)
+       db->upload))
+
+(defn uploads-in-group
+  [conn group-id]
+  (->> (d/q '[:find (pull ?u pull-pattern)
+              :in $ ?group-id pull-pattern
+              :where
+              [?g :group/id ?group-id]
+              [?t :thread/group ?g]
+              [?u :upload/thread ?t]]
+            (d/db conn) group-id upload-pull-pattern)
+       (map (comp db->upload first))
+       (sort-by :uploaded-at)))

--- a/src/braid/server/db/upload.clj
+++ b/src/braid/server/db/upload.clj
@@ -3,11 +3,12 @@
             [braid.server.db.common :refer :all]))
 
 (defn create-upload!
-  [conn {:keys [id url thread-id]}]
+  [conn {:keys [id url thread-id uploader-id uploaded-at]}]
   (->> {:upload/id id
         :upload/url url
         :upload/thread [:thread/id thread-id]
-        :upload/uploaded-at (java.util.Date.)}
+        :upload/uploaded-by [:user/id uploader-id]
+        :upload/uploaded-at uploaded-at}
        (create-entity! conn)
        db->upload))
 

--- a/src/braid/ui/styles/header.cljs
+++ b/src/braid/ui/styles/header.cljs
@@ -112,6 +112,9 @@
           [:&.group-bots:after
            (mixins/fontawesome \uf12e)]
 
+          [:&.group-uploads:after
+           (mixins/fontawesome \uf0ee)]
+
           [:&.settings:after
            (mixins/fontawesome \uf013)]]]]]
 

--- a/src/braid/ui/styles/misc.cljs
+++ b/src/braid/ui/styles/misc.cljs
@@ -219,9 +219,13 @@
      :align-content "space-between"
      :align-item "bottom"}
     [:.upload
-     [:.embed {:width (rem 5)}]
-     {;:width (rem 6)
-      :height (rem 3)
+     [:.embed
+      {:width (rem 5)
+       :margin 0}]
+     [:.uploaded-thread
+      [:.tags
+       {:display "inline"}]]
+     {:height (rem 3)
       :margin (em 1)}]]])
 
 (def tag

--- a/src/braid/ui/styles/misc.cljs
+++ b/src/braid/ui/styles/misc.cljs
@@ -210,6 +210,20 @@
        :border-radius (rem 1)
        :margin-bottom vars/pad}]]]])
 
+(def uploads-page
+  [:.page.uploads
+   [:.uploads
+    {:width "100%"
+     :flex-direction "row"
+     :flex-wrap "wrap"
+     :align-content "space-between"
+     :align-item "bottom"}
+    [:.upload
+     [:.embed {:width (rem 5)}]
+     {;:width (rem 6)
+      :height (rem 3)
+      :margin (em 1)}]]])
+
 (def tag
   [:.tag
    mixins/pill-box])

--- a/src/braid/ui/views/header.cljs
+++ b/src/braid/ui/views/header.cljs
@@ -85,6 +85,15 @@
           :href path}
         "Bots"]))))
 
+(defn group-uploads-view []
+  (let [group-id (subscribe [:open-group-id])]
+    (fn []
+      (let [path (routes/uploads-path {:group-id @group-id})]
+        [:a.group-uploads
+         {:class (when (routes/current-path? path) "active")
+          :href path}
+         "Uploads"]))))
+
 (defn left-header-view []
   (let [group-id (subscribe [:open-group-id])]
     (fn []
@@ -105,6 +114,7 @@
         [subscriptions-link-view]
         [invite-link-view]
         [group-bots-view]
+        [group-uploads-view]
         [edit-profile-link-view]
         [settings-link-view]]])))
 

--- a/src/braid/ui/views/main.cljs
+++ b/src/braid/ui/views/main.cljs
@@ -16,7 +16,9 @@
             [braid.ui.views.pages.group-explore :refer [group-explore-page-view]]
             [braid.ui.views.pages.global-settings :refer [global-settings-page-view]]
             [braid.ui.views.pages.group-settings :refer [group-settings-view]]
-            [braid.ui.views.pages.bots :refer [bots-view]]))
+            [braid.ui.views.pages.bots :refer [bots-view]]
+            [braid.ui.views.pages.uploads :refer [uploads-view]]
+            [braid.ui.views.pages.thread :refer [single-thread-view]]))
 
 (defn page-view []
   (let [page (subscribe [:page])]
@@ -33,6 +35,8 @@
         :invite [invite-page-view]
         :group-explore [group-explore-page-view]
         :bots [bots-view]
+        :uploads [uploads-view]
+        :thread [single-thread-view]
         :settings [group-settings-view]
         :global-settings [global-settings-page-view]
         (do (routes/go-to! (routes/index-path))

--- a/src/braid/ui/views/new_message.cljs
+++ b/src/braid/ui/views/new_message.cljs
@@ -274,8 +274,8 @@
                              (s3/upload (aget (.. e -target -files) 0)
                                         (fn [url]
                                           (reset! uploading? false)
-                                          (dispatch! :new-message
-                                                     {:content url
+                                          (dispatch! :create-upload
+                                                     {:url url
                                                       :group-id (config :group-id)
                                                       :thread-id (config :thread-id)}))))}]])))
 

--- a/src/braid/ui/views/pages/thread.cljs
+++ b/src/braid/ui/views/pages/thread.cljs
@@ -1,0 +1,25 @@
+(ns braid.ui.views.pages.thread
+  (:require [reagent.core :as r]
+            [reagent.ratom :refer-macros [reaction]]
+            [chat.client.reagent-adapter :refer [subscribe]]
+            [braid.ui.views.thread :refer [thread-view]]
+            [chat.client.dispatcher :refer [dispatch!]]))
+
+(defn single-thread-view
+  []
+  (let [page (subscribe [:page])
+        group-id (subscribe [:open-group-id])
+        thread-id (reaction (first (@page :thread-ids)))
+        all-threads (subscribe [:threads])
+        thread (reaction (if-let [th (get @all-threads @thread-id)]
+                           th
+                           (do (dispatch! :load-threads
+                                          {:thread-ids [@thread-id]})
+                               nil)))]
+    (fn []
+      [:div.page.single-thread
+       [:div.title "Thread"]
+       [:div.content
+        (if-let [th @thread]
+          [thread-view th]
+          [:div.loading])]])))

--- a/src/braid/ui/views/pages/thread.cljs
+++ b/src/braid/ui/views/pages/thread.cljs
@@ -10,16 +10,13 @@
   (let [page (subscribe [:page])
         group-id (subscribe [:open-group-id])
         thread-id (reaction (first (@page :thread-ids)))
-        all-threads (subscribe [:threads])
-        thread (reaction (if-let [th (get @all-threads @thread-id)]
-                           th
-                           (do (dispatch! :load-threads
-                                          {:thread-ids [@thread-id]})
-                               nil)))]
+        thread (subscribe [:thread] [thread-id])]
     (fn []
       [:div.page.single-thread
        [:div.title "Thread"]
        [:div.content
         (if-let [th @thread]
           [thread-view th]
-          [:div.loading])]])))
+          (do (dispatch! :load-threads
+                         {:thread-ids [@thread-id]})
+            [:div.loading]))]])))

--- a/src/braid/ui/views/pages/uploads.cljs
+++ b/src/braid/ui/views/pages/uploads.cljs
@@ -5,6 +5,7 @@
             [chat.client.reagent-adapter :refer [subscribe]]
             [chat.client.dispatcher :refer [dispatch!]]
             [chat.client.routes :as routes]
+            [chat.client.views.helpers :as helpers]
             [braid.ui.views.embed :refer [embed-view]]
             [braid.ui.views.pills :as pills]
             [braid.ui.views.thread :as thread]))
@@ -33,7 +34,7 @@
           [:td.uploaded-thread
            [:a {:href (routes/thread-path {:group-id @group-id
                                            :thread-id (upload :thread-id)})}
-            (str "Uploaded at " (upload :uploaded-at))]
+            (str "Uploaded at " (helpers/format-date (upload :uploaded-at)))]
            [:br]
            (if @thread
              [:span "Tagged with " [thread/thread-tags-view @thread]]

--- a/src/braid/ui/views/pages/uploads.cljs
+++ b/src/braid/ui/views/pages/uploads.cljs
@@ -21,7 +21,7 @@
 (defn uploads-view
   []
   (let [group-id (subscribe [:open-group-id])
-        uploads (r/atom [])
+        uploads (r/atom :initial)
         get-uploads (run! (dispatch! :get-group-uploads
                                      {:group-id @group-id
                                       :on-complete (partial reset! uploads)}))]
@@ -30,10 +30,14 @@
         [:div.page.uploads
          [:div.title "Uploads"]
          [:div.content
-          [:table.uploads
-           [:thead
-            [:tr [:th ""] [:th ""] [:th ""]]]
-           (into [:tbody]
-                 (for [upload @uploads]
-                   ^{:key (upload :id)}
-                   [upload-view upload]))]]]))))
+          (cond
+            (= :initial @uploads) [:div.loading "Loading..."]
+            (empty? @uploads) [:p "No uploads in this group yet"]
+            :else
+            [:table.uploads
+             [:thead
+              [:tr [:th ""] [:th ""] [:th ""]]]
+             (into [:tbody]
+                   (for [upload @uploads]
+                     ^{:key (upload :id)}
+                     [upload-view upload]))])]]))))

--- a/src/braid/ui/views/pages/uploads.cljs
+++ b/src/braid/ui/views/pages/uploads.cljs
@@ -1,0 +1,39 @@
+(ns braid.ui.views.pages.uploads
+  (:require [reagent.core :as r]
+            [reagent.ratom :refer-macros [run!]]
+            [clojure.string :as string]
+            [chat.client.reagent-adapter :refer [subscribe]]
+            [braid.ui.views.embed :refer [embed-view]]
+            [chat.client.dispatcher :refer [dispatch!]]
+            [chat.client.routes :as routes]))
+
+(defn upload-view
+  [upload]
+  (let [group-id (subscribe [:open-group-id])]
+    (fn [upload]
+      [:tr.upload
+       [:td [embed-view (upload :url)]]
+       [:td (js/decodeURIComponent (last (string/split (upload :url) #"/")))]
+       [:td [:a {:href (routes/thread-path {:group-id @group-id
+                                            :thread-id (upload :thread-id)})}
+             (str "Uploaded at " (upload :uploaded-at))]]])))
+
+(defn uploads-view
+  []
+  (let [group-id (subscribe [:open-group-id])
+        uploads (r/atom [])
+        get-uploads (run! (dispatch! :get-group-uploads
+                                     {:group-id @group-id
+                                      :on-complete (partial reset! uploads)}))]
+    (fn []
+      (let [_ @get-uploads]
+        [:div.page.uploads
+         [:div.title "Uploads"]
+         [:div.content
+          [:table.uploads
+           [:thead
+            [:tr [:th ""] [:th ""] [:th ""]]]
+           (into [:tbody]
+                 (for [upload @uploads]
+                   ^{:key (upload :id)}
+                   [upload-view upload]))]]]))))

--- a/src/braid/ui/views/styles.cljs
+++ b/src/braid/ui/views/styles.cljs
@@ -38,6 +38,7 @@
                braid.ui.styles.misc/settings-page
                braid.ui.styles.misc/me-page
                braid.ui.styles.misc/bots-page
+               braid.ui.styles.misc/uploads-page
                braid.ui.styles.login/login
                braid.ui.styles.misc/tag
                braid.ui.styles.misc/user

--- a/src/braid/ui/views/thread.cljs
+++ b/src/braid/ui/views/thread.cljs
@@ -119,10 +119,10 @@
             (do (set-uploading! true)
                 (s3/upload file (fn [url]
                                   (set-uploading! false)
-                                  (dispatch! :new-message
-                                             {:content url
-                                              :group-id (thread :group-id)
-                                              :thread-id (thread :id)}))))))]
+                                  (dispatch! :create-upload
+                                             {:url url
+                                              :thread-id (thread :id)
+                                              :group-id (thread :group-id)}))))))]
 
     (fn [thread]
       (let [{:keys [dragging? uploading? focused?]} @state

--- a/src/chat/client/dispatcher.cljs
+++ b/src/chat/client/dispatcher.cljs
@@ -275,6 +275,11 @@
       (when-let [bot (:braid/ok reply)]
         (on-complete bot)))))
 
+(defmethod dispatch! :create-upload [_ {:keys [url thread-id group-id]}]
+  (sync/chsk-send! [:braid.server/create-upload
+                    (schema/make-upload {:url url :thread-id thread-id})])
+  (dispatch! :new-message {:content url :thread-id thread-id :group-id group-id}))
+
 (defmethod dispatch! :check-auth! [_ _]
   (edn-xhr {:uri "/check"
             :method :get

--- a/src/chat/client/dispatcher.cljs
+++ b/src/chat/client/dispatcher.cljs
@@ -280,6 +280,17 @@
                     (schema/make-upload {:url url :thread-id thread-id})])
   (dispatch! :new-message {:content url :thread-id thread-id :group-id group-id}))
 
+(defmethod dispatch! :get-group-uploads [_ {:keys [group-id on-complete]}]
+  (sync/chsk-send!
+    [:braid.server/uploads-in-group group-id]
+    5000
+    (fn [reply]
+      (if-let [uploads (:braid/ok reply)]
+        (on-complete uploads)
+        (store/display-error! :upload-fetch-failed
+                              "Couldn't get uploads in group"
+                              :info)))))
+
 (defmethod dispatch! :check-auth! [_ _]
   (edn-xhr {:uri "/check"
             :method :get

--- a/src/chat/client/reagent_adapter.cljs
+++ b/src/chat/client/reagent_adapter.cljs
@@ -151,6 +151,10 @@
   state/get-user)
 
 (register-sub
+  :thread
+  state/get-thread)
+
+(register-sub
   :threads
   state/get-threads)
 

--- a/src/chat/client/routes.cljs
+++ b/src/chat/client/routes.cljs
@@ -34,6 +34,14 @@
 (defroute bots-path "/:group-id/bots" [group-id]
   (store/set-group-and-page! (UUID. group-id nil) {:type :bots}))
 
+(defroute uploads-path "/:group-id/uploads" [group-id]
+  (store/set-group-and-page! (UUID. group-id nil) {:type :uploads}))
+
+(defroute thread-path "/:group-id/thread/:thread-id" [group-id thread-id]
+  (store/set-group-and-page! (UUID. group-id nil)
+                             {:type :thread
+                              :thread-ids [(UUID. thread-id nil)]}))
+
 (defroute group-settings-path "/:group-id/settings" [group-id]
   (store/set-group-and-page! (UUID. group-id nil) {:type :settings}))
 

--- a/src/chat/client/schema.cljs
+++ b/src/chat/client/schema.cljs
@@ -37,3 +37,7 @@
 (defn make-bot [data]
   (merge {:id (uuid/make-random-squuid)}
          data))
+
+(defn make-upload [data]
+  (merge {:id (uuid/make-random-squuid)}
+         data))

--- a/src/chat/server/db.clj
+++ b/src/chat/server/db.clj
@@ -4,9 +4,9 @@
             [braid.server.conf :refer [config]]
             [clojure.edn :as edn]
             [clojure.string :as string]
-            [braid.server.db.common :refer :all] ; XXX: temp
             [chat.server.schema :refer [schema]]
-            [braid.server.db user message group invitation thread tag bot]))
+            [braid.server.db user message group invitation thread tag bot
+             upload]))
 
 (defn init!
   "set up schema"
@@ -65,3 +65,5 @@
 (reexport-db-ns braid.server.db.tag)
 
 (reexport-db-ns braid.server.db.bot)
+
+(reexport-db-ns braid.server.db.upload)

--- a/src/chat/server/migrate.clj
+++ b/src/chat/server/migrate.clj
@@ -5,6 +5,33 @@
             [clojure.set :as set]
             [clojure.edn :as edn]))
 
+(defn migrate-2016-06-27
+  "Add uploads schema"
+  []
+  (d/transact db/conn
+    [{:db/ident :upload/id
+      :db/valueType :db.type/uuid
+      :db/cardinality :db.cardinality/one
+      :db/unique :db.unique/identity
+      :db/id #db/id [:db.part/db]
+      :db.install/_attribute :db.part/db}
+     {:db/ident :upload/thread
+      :db/doc "The thread this upload is associated with"
+      :db/valueType :db.type/ref
+      :db/cardinality :db.cardinality/one
+      :db/id #db/id [:db.part/db]
+      :db.install/_attribute :db.part/db}
+     {:db/ident :upload/url
+      :db/valueType :db.type/string
+      :db/cardinality :db.cardinality/one
+      :db/id #db/id [:db.part/db]
+      :db.install/_attribute :db.part/db}
+     {:db/ident :upload/uploaded-at
+      :db/valueType :db.type/instant
+      :db/cardinality :db.cardinality/one
+      :db/id #db/id [:db.part/db]
+      :db.install/_attribute :db.part/db}]))
+
 (defn migrate-2016-06-08
   "Add bot schema"
   []

--- a/src/chat/server/migrate.clj
+++ b/src/chat/server/migrate.clj
@@ -30,6 +30,12 @@
       :db/valueType :db.type/instant
       :db/cardinality :db.cardinality/one
       :db/id #db/id [:db.part/db]
+      :db.install/_attribute :db.part/db}
+     {:db/ident :upload/uploaded-by
+      :db/doc "User that uploaded this file"
+      :db/valueType :db.type/ref
+      :db/cardinality :db.cardinality/one
+      :db/id #db/id [:db.part/db]
       :db.install/_attribute :db.part/db}]))
 
 (defn migrate-2016-06-08

--- a/src/chat/server/schema.clj
+++ b/src/chat/server/schema.clj
@@ -127,6 +127,12 @@
   :db/cardinality :db.cardinality/one
   :db/id #db/id [:db.part/db]
   :db.install/_attribute :db.part/db}
+ {:db/ident :upload/uploaded-by
+  :db/doc "User that uploaded this file"
+  :db/valueType :db.type/ref
+  :db/cardinality :db.cardinality/one
+  :db/id #db/id [:db.part/db]
+  :db.install/_attribute :db.part/db}
 
  ; thread
  {:db/ident :thread/id

--- a/src/chat/server/schema.clj
+++ b/src/chat/server/schema.clj
@@ -104,6 +104,30 @@
   :db/id #db/id [:db.part/db]
   :db.install/_attribute :db.part/db}
 
+ ; upload
+ {:db/ident :upload/id
+  :db/valueType :db.type/uuid
+  :db/cardinality :db.cardinality/one
+  :db/unique :db.unique/identity
+  :db/id #db/id [:db.part/db]
+  :db.install/_attribute :db.part/db}
+ {:db/ident :upload/thread
+  :db/doc "The thread this upload is associated with"
+  :db/valueType :db.type/ref
+  :db/cardinality :db.cardinality/one
+  :db/id #db/id [:db.part/db]
+  :db.install/_attribute :db.part/db}
+ {:db/ident :upload/url
+  :db/valueType :db.type/string
+  :db/cardinality :db.cardinality/one
+  :db/id #db/id [:db.part/db]
+  :db.install/_attribute :db.part/db}
+ {:db/ident :upload/uploaded-at
+  :db/valueType :db.type/instant
+  :db/cardinality :db.cardinality/one
+  :db/id #db/id [:db.part/db]
+  :db.install/_attribute :db.part/db}
+
  ; thread
  {:db/ident :thread/id
   :db/valueType :db.type/uuid

--- a/src/chat/server/sync.clj
+++ b/src/chat/server/sync.clj
@@ -480,9 +480,12 @@
 
 (defmethod event-msg-handler :braid.server/create-upload
   [{:as ev-msg :keys [?data user-id]}]
-  (when (and (upload-valid? ?data)
-          (db/user-in-group? user-id (db/thread-group-id (?data :thread-id))))
-    (db/create-upload! ?data)))
+  (let [upload (assoc ?data
+                 :uploaded-at (java.util.Date.)
+                 :uploader-id user-id)]
+    (when (and (upload-valid? upload)
+            (db/user-in-group? user-id (db/thread-group-id (upload :thread-id))))
+      (db/create-upload! upload))))
 
 (defmethod event-msg-handler :braid.server/uploads-in-group
   [{:as ev-msg :keys [?data user-id ?reply-fn]}]

--- a/src/chat/server/sync.clj
+++ b/src/chat/server/sync.clj
@@ -484,11 +484,11 @@
           (db/user-in-group? user-id (db/thread-group-id (?data :thread-id))))
     (db/create-upload! ?data)))
 
-(defmethod event-msg-handler :braid.server/upload-in-group
+(defmethod event-msg-handler :braid.server/uploads-in-group
   [{:as ev-msg :keys [?data user-id ?reply-fn]}]
   (when ?reply-fn
     (if (db/user-in-group? user-id ?data)
-      (?reply-fn {:braid/ok (db/uploads-in-group)})
+      (?reply-fn {:braid/ok (db/uploads-in-group ?data)})
       (?reply-fn {:braid/error "Not allowed"}))))
 
 (defmethod event-msg-handler :braid.server/start


### PR DESCRIPTION
Have uploads as db type, create one with new upload; use this to facilitate viewing all uploads in a group.

Additionally adds the ability to link to a particular thread by id, which we use to enable viewing the source thread of an upload