### PR TITLE
GitHub auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 14 July 2016
+
+  - Show user availability status in autocomplete

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 ## 14 July 2016
 
+  - Thread close keyboard shortcuts now triggers on key down instead of key up (to prevent confusing interactions with autocomplete key handlers)
   - Show user availability status in autocomplete

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 18 July 2016
+
+  - Prevent tag box in autocomplete from collapsing (and highlighting looking weird) when the tag has no description
+
 ## 16 July 2016
 
   - Show changelog in app

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-## 20 July 2016
+## 21 July 2016
 
   - Add ability to log in and register (via link or to public groups) with a GitHub account
+
+## 20 July 2016
+
   - Fix bug that prevented file add button in reply field from working
 
 ## 18 July 2016

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 20 July 2016
+
+  - Add ability to log in and register (via link or to public groups) with a GitHub account
+
 ## 18 July 2016
 
   - Prevent tag box in autocomplete from collapsing (and highlighting looking weird) when the tag has no description

--- a/deploying.md
+++ b/deploying.md
@@ -135,7 +135,7 @@ add a supervisor entry for the chat app, something like this:
 ```
 [program:chat]
 command=java -server -Xmx1g -Dfile.encoding=UTF8 -jar /www/deploys/chat/chat.jar 5555 3081
-environment=ENVIRONMENT="prod",TESTER_PASSWORD="test user password",DB_URL="datomic:sql://chat_prod?jdbc:postgresql://localhost:5432/datomic?user=datomic&password=datomic",TIMBRE_LEVER=":debug",MALIGUN_PASSWORD="XXX",MAILGUN_DOMAIN="chat.leanpixel.com",AWS_DOMAIN="chat.leanpixel.com",AWS_ACCESS_KEY="XXX",AWS_SECRET_KEY="...",S3_UPLOAD_KEY="XXX",S#_UPLOAD_SECRET="XXX",ASANA_CLIENT_ID="XXX",ASANA_CLIENT_SECRET="XXX",API_DOMAIN="api.mydomain.com"
+environment=ENVIRONMENT="prod",TESTER_PASSWORD="test user password",DB_URL="datomic:sql://chat_prod?jdbc:postgresql://localhost:5432/datomic?user=datomic&password=datomic",TIMBRE_LEVER=":debug",MALIGUN_PASSWORD="XXX",MAILGUN_DOMAIN="chat.leanpixel.com",AWS_DOMAIN="chat.leanpixel.com",AWS_ACCESS_KEY="XXX",AWS_SECRET_KEY="...",S3_UPLOAD_KEY="XXX",S#_UPLOAD_SECRET="XXX",ASANA_CLIENT_ID="XXX",ASANA_CLIENT_SECRET="XXX",API_DOMAIN="api.mydomain.com",GITHUB_CLIENT_ID="XXX",GITHUB_CLIENT_ID="XXX"
 autostart=true
 autorestart=true
 startsecs=10

--- a/developing.md
+++ b/developing.md
@@ -158,6 +158,9 @@ In the project folder, create a profile
         :s3-upload-secret "secret-for-uploading"
         ; for link info extraction
         :embedly-key "embedly api key"
+        ; for github login
+        :github-client-id "..."
+        :github-client-secret "..."
         }}}
 ```
 

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
                  [javax.servlet/servlet-api "2.5"]
                  [commons-codec "1.10"]
                  [commons-validator "1.5.1"]
-                 [http-kit "2.2.0-alpha1"]
+                 [http-kit "2.2.0"]
                  [ring/ring-defaults "0.2.1"]
                  [fogus/ring-edn "0.3.0"]
                  [ring-cors "0.1.8"]

--- a/src/braid/client/state.cljs
+++ b/src/braid/client/state.cljs
@@ -125,10 +125,12 @@
 
 (defmethod subscription :page-path
   [state _]
-  (let [page (subscription state [:page])]
+  (let [page (subscription state [:page])
+        open-group (subscription state [:open-group-id])]
     (reaction
-      ; depend on page, so when the page changes this sub updates too
+      ; depend on page & group, so when the page changes this sub updates too
       (do @page
+          @open-group
           (.getPath (.parse Uri js/window.location))))))
 
 (defmethod subscription :thread

--- a/src/braid/client/ui/views/autocomplete.cljs
+++ b/src/braid/client/ui/views/autocomplete.cljs
@@ -5,7 +5,8 @@
             [clojure.string :as string]
             [braid.client.helpers :refer [id->color debounce]]
             [braid.client.dispatcher :refer [dispatch!]]
-            [braid.client.emoji :as emoji])
+            [braid.client.emoji :as emoji]
+            [goog.string :as gstring])
   (:import [goog.events KeyCodes]))
 
 ; fn that returns results that will be shown if pattern matches
@@ -149,7 +150,8 @@
                                (when (store/is-subscribed-to-tag? (tag :id))
                                  {:backgroundColor (id->color (tag :id))}))}]
                            [:div.name (tag :name)]
-                           [:div.extra (tag :description)]])}))
+                           [:div.extra (or (tag :description)
+                                           (gstring/unescapeEntities "&nbsp;"))]])}))
                 (cons (when-not (or exact-match? (string/blank? query))
                         (let [tag (schema/make-tag
                                     {:name query

--- a/src/braid/client/ui/views/autocomplete.cljs
+++ b/src/braid/client/ui/views/autocomplete.cljs
@@ -117,7 +117,7 @@
                         [:div.user-match
                           [:img.avatar {:src (user :avatar)}]
                           [:div.name (user :nickname)]
-                          [:div.extra "..."]])}))))))
+                          [:div.extra (user :status)]])}))))))
 
    ; ... #<tag>   -> autocompletes tag
    (fn [text]

--- a/src/braid/client/ui/views/header.cljs
+++ b/src/braid/client/ui/views/header.cljs
@@ -35,7 +35,7 @@
         [:a {:class (str class (when (= path @current-path) " active"))
              :href path
              :title title}
-         (when body body)]))))
+         body]))))
 
 (def left-headers
   [{:title "Inbox"

--- a/src/braid/client/ui/views/thread.cljs
+++ b/src/braid/client/ui/views/thread.cljs
@@ -167,7 +167,7 @@
             (set-focused! false)
             (dispatch! :mark-thread-read (thread :id)))
 
-          :on-key-up
+          :on-key-down
           (fn [e]
             (when (or (and
                         (= KeyCodes.X (.-keyCode e))

--- a/src/braid/server/api/github.clj
+++ b/src/braid/server/api/github.clj
@@ -1,0 +1,55 @@
+(ns braid.server.api.github
+  (:require [org.httpkit.client :as http]
+            [clojure.data.json :as json]
+            [braid.server.conf :refer [config]]
+            [braid.server.cache :as cache]
+            [braid.server.crypto :as crypto]
+            [braid.server.db :as db]
+            [braid.server.util :refer [map->query-str]]))
+
+(defn build-authorize-link
+  []
+  (let [state (crypto/random-nonce 20)]
+    (cache/cache-set! state (.getTime (java.util.Date.)))
+    (str "https://github.com/login/oauth/authorize?"
+         (map->query-str
+           {:client_id (config :github-client-id)
+            :scope "user:email"
+            :redirect_uri (str (config :site-url) "/oauth/github")
+            :state state}))))
+
+(defn exchange-token
+  [code state]
+  (when-let [ts (cache/cache-get state)]
+    (cache/cache-del! state)
+    ; Was the request from the last 30 minutes?
+    (when (< 0 (- (.getTime (java.util.Date.)) (Long. ts)) (* 1000 60 30))
+      (let [resp @(http/post "https://github.com/login/oauth/access_token"
+                             {:headers {"Accept" "application/json"}
+                              :form-params
+                              {:client_id (config :github-client-id)
+                               :client_secret (config :github-client-secret)
+                               :code code
+                               :redirect_uri (str (config :site-url) "/oauth/github")
+                               :state state}})]
+        (json/read-str (:body resp) :key-fn keyword)))))
+
+(defn email-address
+  [token]
+  (let [resp @(http/get "https://api.github.com/user/emails"
+                {:headers {"Authorization" (str "token " token)}})
+        emails (json/read-str (:body resp) :key-fn keyword)]
+    (->> emails
+         (filter #(and (:verified %) (:primary %)) )
+         first
+         :email)))
+
+(defn login
+  [token]
+  (let [email (email-address token)]
+    (db/user-with-email email)))
+
+(defn register
+  [token]
+  ; TODO: create a passwordless user with email
+  )

--- a/src/braid/server/conf.clj
+++ b/src/braid/server/conf.clj
@@ -17,6 +17,8 @@
                        :db-url
                        :embedly-key
                        :environment
+                       :github-client-id
+                       :github-client-secret
                        :hmac-secret
                        :mailgun-domain
                        :mailgun-password

--- a/src/braid/server/routes/client.clj
+++ b/src/braid/server/routes/client.clj
@@ -55,6 +55,11 @@
        :headers {"Content-Type" "text/plain"}
        :body "Bad user or token"}))
 
+  ; OAuth redirect
+  (GET "/oauth/github" [code state :as req]
+    (println "GITHUB OAUTH" (pr-str code) (pr-str state))
+    )
+
   ; everything else
   (GET "/*" []
     (get-html "desktop")))

--- a/src/braid/server/schema.clj
+++ b/src/braid/server/schema.clj
@@ -48,7 +48,6 @@
   :db/id #db/id [:db.part/db]
   :db.install/_attribute :db.part/db}
  ; user - preferences
- ; TODO: make preferences entities, instead of string
  {:db/ident :user/preferences
   :db/valueType :db.type/ref
   :db/cardinality :db.cardinality/many

--- a/src/braid/server/sync.clj
+++ b/src/braid/server/sync.clj
@@ -1,8 +1,7 @@
 (ns braid.server.sync
   (:require [mount.core :as mount :refer [defstate]]
             [taoensso.sente :as sente]
-            [taoensso.sente.server-adapters.http-kit
-             :refer [sente-web-server-adapter]]
+            [taoensso.sente.server-adapters.http-kit :refer [get-sch-adapter]]
             [taoensso.sente.packers.transit :as sente-transit]
             [compojure.core :refer [GET POST routes defroutes context]]
             [ring.middleware.anti-forgery :refer [*anti-forgery-token*]]
@@ -26,7 +25,7 @@
 (let [packer (sente-transit/get-transit-packer :json)
       {:keys [ch-recv send-fn ajax-post-fn ajax-get-or-ws-handshake-fn
               connected-uids]}
-      (sente/make-channel-socket! sente-web-server-adapter
+      (sente/make-channel-socket! (get-sch-adapter)
                                   {:user-id-fn
                                    (fn [ob] (get-in ob [:session :user-id]))
                                    :packer packer})]

--- a/src/braid/server/util.clj
+++ b/src/braid/server/util.clj
@@ -1,5 +1,7 @@
 (ns braid.server.util
-  (:import org.apache.commons.validator.UrlValidator))
+  (:require [clojure.string :as string])
+  (:import java.net.URLEncoder
+           org.apache.commons.validator.UrlValidator))
 
 (defn valid-url?
   "Check if the string is a valid http(s) url.  Note that this will *not*
@@ -8,3 +10,9 @@
   ([s schemes]
    (and (string? s)
      (.isValid (UrlValidator. (into-array schemes)) s))))
+
+(defn map->query-str
+  [m]
+  (->> m
+       (map (fn [[k v]] (str (name k) "=" (URLEncoder/encode (str v)))))
+       (string/join "&")))


### PR DESCRIPTION
Users can now login and sign up via GitHub.  Signing up via github only works for either public groups or invite links though -- seemed like more trouble than it'd be worth (and would not entirely make sense) to have email invites work with Github.

Login styling could use some work and registering pages are still entirely unstyled, but the next issue I'm going to tackle for Braid client is moving those register pages into the CLJS client.

![screenshot-2016-07-20_15 01 31_edt-04 00_1469041291](https://cloud.githubusercontent.com/assets/38405/16999219/e3eb08f8-4e8a-11e6-9336-16c69b191a60.png)
