### PR TITLE
Fix documentation for which servers are started on which ports

### DIFF
--- a/docs/dev/how-to/getting-up-and-running-in-development.md
+++ b/docs/dev/how-to/getting-up-and-running-in-development.md
@@ -69,7 +69,7 @@ To get the server running:
   (dev-main 5555)
   ```
 
-This will start the API server on port 5555, the desktop client server on 5556 and the mobile client server on 5557.
+This will start the desktop client server on 5555, the mobile client server on 5556, and the API server on port 5557.
 
 4. Seed some data (first time only):
 


### PR DESCRIPTION
The port numbers in the documentation are incorrect.

This is what I see when I run `(dev-main 5555)`:
![screen shot 2017-10-05 at 2 50 57 pm](https://user-images.githubusercontent.com/1088336/31228143-af111e98-a9dc-11e7-84c6-edced7fdce03.png)
