### PR TITLE
Delete uploads

### DIFF
--- a/src/braid/core/client/uploads/events.cljs
+++ b/src/braid/core/client/uploads/events.cljs
@@ -27,3 +27,8 @@
          (if-let [uploads (:braid/ok reply)]
            (on-success uploads)
            (on-error (get reply :braid/error "Couldn't get uploads in group")))))}))
+
+(reg-event-fx
+  :core.uploads/delete-upload
+  (fn [cofx [_ upload-id]]
+    {:websocket-send (list [:braid.server/delete-upload upload-id])}))

--- a/src/braid/core/client/uploads/views/uploads_page_styles.cljs
+++ b/src/braid/core/client/uploads/views/uploads_page_styles.cljs
@@ -20,6 +20,10 @@
 
       [:>tr.upload
 
+       [:>td.delete
+        [:>button
+         {:font-family "fontawesome"
+          :color "red"}]]
        [:>td.uploaded-file
 
         [:>.embed

--- a/src/braid/core/server/s3.clj
+++ b/src/braid/core/server/s3.clj
@@ -1,8 +1,8 @@
 (ns braid.core.server.s3
   (:require
-    [clojure.data.json :as json]
-    [clojure.string :as string]
-    [braid.core.server.conf :refer [config]])
+   [braid.core.server.conf :refer [config]]
+   [clojure.data.json :as json]
+   [clojure.string :as string])
   (:import
    (javax.crypto Mac)
    (javax.crypto.spec SecretKeySpec)

--- a/src/braid/core/server/uploads.clj
+++ b/src/braid/core/server/uploads.clj
@@ -1,0 +1,19 @@
+(ns braid.core.server.uploads
+  (:require
+   [aws.sdk.s3 :as s3]
+   [braid.core.server.conf :refer [config]]))
+
+(defn upload-url-path
+  [url]
+  (some->
+    (re-pattern (str "^https://s3.amazonaws.com/"
+                     (config :aws-domain)
+                     "/(.*)$"))
+    (re-matches url)
+    second))
+
+(defn delete-upload
+  [upload-path]
+  (let [creds {:access-key (config :aws-access-key)
+               :secret-key (config :aws-secret-key)}]
+    (s3/delete-object creds (config :aws-domain) upload-path)))


### PR DESCRIPTION
Adding the ability to delete uploads; in this case (unlike deleting messages) it can be destructive, because it will also remove files from S3 storage, as well as from Datomic.

It seems like something that would be useful though (and can help maybe clean out the s3 bucket...)