### PR TITLE
Thread Border Styling

### DIFF
--- a/src/braid/core/client/helpers.cljs
+++ b/src/braid/core/client/helpers.cljs
@@ -7,6 +7,7 @@
    [cljs-time.core :as t]
    [cljs-time.format :as f]
    [cljsjs.husl]
+   [garden.color :as color]
    [goog.style :as gstyle])
   (:import
    (goog Uri)))
@@ -98,6 +99,9 @@
 
 (defn ->color [input]
   (js/window.HUSL.toHex (mod (Math/abs (hash input)) 360) 95 50))
+
+(defn darken [color]
+  (color/as-hex (color/darken color 15)))
 
 (defn id->color [uuid]
   (->color uuid))

--- a/src/braid/core/client/helpers.cljs
+++ b/src/braid/core/client/helpers.cljs
@@ -100,9 +100,6 @@
 (defn ->color [input]
   (js/window.HUSL.toHex (mod (Math/abs (hash input)) 360) 95 50))
 
-(defn darken [color]
-  (color/as-hex (color/darken color 15)))
-
 (defn id->color [uuid]
   (->color uuid))
 

--- a/src/braid/core/client/ui/styles/message.cljs
+++ b/src/braid/core/client/ui/styles/message.cljs
@@ -12,7 +12,7 @@
 (def message
   [:>.message
    {:position "relative"
-    :margin [[0 0 pad]]}
+    :padding [[(m// pad 2) pad]]}
 
    [:&.failed-to-send
     {:background-color "rgba(239, 72, 72, 0.53)"}]
@@ -22,33 +22,21 @@
      [:.avatar :.info
       {:display "none"}]]
 
-    [:&.seen
-     {:transition [["opacity" "0.5s" "linear"]]}
-     ; cannot apply opacity to .message or .content or .dummy
-     ; b/c it creates a new stacking context
-     ; causing hover-cards to display under subsequent messages
-     ["> .info"
-      "> .avatar img"
-      "> .footer"
-      "> .content > img"
-      "> .content > .dummy > .user > .pill"
-      "> .content > .dummy > .tag > .pill"
-      "> .content > .dummy > .external"
-      {:opacity 0.6}]
+    [:&.unseen
 
-     ["> .content"
-      {:color "rgba(0,0,0,0.6)"}]]
-
-    [:&.unseen {}]
+     [:>.border
+      (mixins/card-border "8px")]]
 
    [:>.delete
     {:display "none"}]
+
    [:&:hover
     [:>.delete
      {:position "absolute"
       :display "block"
       :right 0
       :z-index 1000}
+
      [:>button
       {:font-family "fontawesome"
        :color "red"}]]]

--- a/src/braid/core/client/ui/styles/message.cljs
+++ b/src/braid/core/client/ui/styles/message.cljs
@@ -25,7 +25,7 @@
     [:&.unseen
 
      [:>.border
-      (mixins/card-border "8px")]]
+      (mixins/card-border "9px")]]
 
    [:>.delete
     {:display "none"}]

--- a/src/braid/core/client/ui/styles/mixins.cljs
+++ b/src/braid/core/client/ui/styles/mixins.cljs
@@ -114,3 +114,12 @@
      :right (m/* vars/pad 0.70)
      :color "white"
      :font-size "1.5em"}]])
+
+(defn card-border [width]
+  {:position "absolute"
+   ; background overriden inline
+   :background "#000"
+   :top 0
+   :left 0
+   :bottom 0
+   :width width})

--- a/src/braid/core/client/ui/styles/thread.cljs
+++ b/src/braid/core/client/ui/styles/thread.cljs
@@ -144,20 +144,23 @@
 
    [:&.focused
     [:>.card
-     {:box-shadow [[0 (px 10) (px 10) (px 10) "#ccc"]]}]]
+     {:box-shadow [[(px 1) (px 1) (px 4) 0 "#999"]]}]]
 
    [:>.card
     mixins/flex
     {:flex-direction "column"
      :box-shadow [[0 (px 1) (px 3) 0 "#bbb"]]
-     :transition [["box-shadow" "0.2s"]]
      :max-height "100%"
      :background "white"
-     :border-left "4px solid #000" ; color overriden inline
      :border-radius [[vars/border-radius
-                      vars/border-radius 0 0]]}
-    (drag-and-drop pad)
+                      vars/border-radius 0 0]]
+     :position "relative"
+     :overflow "hidden"}
 
+    [:>.border
+     (mixins/card-border "4px")]
+
+    (drag-and-drop pad)
     (head pad)
     (messages pad)]])
 

--- a/src/braid/core/client/ui/styles/thread.cljs
+++ b/src/braid/core/client/ui/styles/thread.cljs
@@ -115,7 +115,9 @@
    ; switch to ::after to align at top
    [:&::before
     {:content "\"\""
-     :flex-grow 1}]
+     :flex-grow 1
+     ; have 1px so card shadow shows
+     :min-height "1px"}]
 
    ;; XXX: does this class actually apply to anything?
    [:&.archived :&.limbo :&.private

--- a/src/braid/core/client/ui/styles/thread.cljs
+++ b/src/braid/core/client/ui/styles/thread.cljs
@@ -95,7 +95,7 @@
   [:>.messages
    {:position "relative"
     :overflow-y "auto"
-    :padding [[0 pad]]}])
+    :overflow-x "hidden"}])
 
 (defn thread [pad]
   [:>.thread

--- a/src/braid/core/client/ui/styles/thread.cljs
+++ b/src/braid/core/client/ui/styles/thread.cljs
@@ -149,7 +149,7 @@
    [:>.card
     mixins/flex
     {:flex-direction "column"
-     :box-shadow [[0 (px 1) (px 2) 0 "#ccc"]]
+     :box-shadow [[0 (px 1) (px 3) 0 "#bbb"]]
      :transition [["box-shadow" "0.2s"]]
      :max-height "100%"
      :background "white"

--- a/src/braid/core/client/ui/styles/thread.cljs
+++ b/src/braid/core/client/ui/styles/thread.cljs
@@ -160,7 +160,7 @@
      :overflow "hidden"}
 
     [:>.border
-     (mixins/card-border "3px")]
+     (mixins/card-border "4px")]
 
     (drag-and-drop pad)
     (head pad)

--- a/src/braid/core/client/ui/styles/thread.cljs
+++ b/src/braid/core/client/ui/styles/thread.cljs
@@ -146,21 +146,19 @@
 
    [:&.focused
     [:>.card
-     {:box-shadow [[(px 1) (px 1) (px 4) 0 "#999"]]}]]
+     [:>.border
+     (mixins/card-border "5px")]]]
 
    [:>.card
     mixins/flex
     {:flex-direction "column"
-     :box-shadow [[0 (px 1) (px 3) 0 "#bbb"]]
+     :box-shadow [[0 (px 1) (px 4) 0 "#c3c3c3"]]
      :max-height "100%"
      :background "white"
      :border-radius [[vars/border-radius
                       vars/border-radius 0 0]]
      :position "relative"
      :overflow "hidden"}
-
-    [:>.border
-     (mixins/card-border "4px")]
 
     (drag-and-drop pad)
     (head pad)

--- a/src/braid/core/client/ui/styles/thread.cljs
+++ b/src/braid/core/client/ui/styles/thread.cljs
@@ -160,7 +160,7 @@
      :overflow "hidden"}
 
     [:>.border
-     (mixins/card-border "4px")]
+     (mixins/card-border "3px")]
 
     (drag-and-drop pad)
     (head pad)

--- a/src/braid/core/client/ui/styles/thread.cljs
+++ b/src/braid/core/client/ui/styles/thread.cljs
@@ -153,6 +153,7 @@
      :transition [["box-shadow" "0.2s"]]
      :max-height "100%"
      :background "white"
+     :border-left "4px solid #000" ; color overriden inline
      :border-radius [[vars/border-radius
                       vars/border-radius 0 0]]}
     (drag-and-drop pad)

--- a/src/braid/core/client/ui/views/card_border.cljs
+++ b/src/braid/core/client/ui/views/card_border.cljs
@@ -4,9 +4,6 @@
     [braid.core.client.helpers :as helpers]))
 
 (defn card-border-view [thread-id]
-  (let [color (helpers/->color @(subscribe [:open-group-id]))]
-    [:div.border
-     {:style
-      {:background (if @(subscribe [:thread-focused? thread-id])
-                     (helpers/darken color)
-                     color)}}]))
+  [:div.border
+   {:style
+    {:background (helpers/->color @(subscribe [:open-group-id]))}}])

--- a/src/braid/core/client/ui/views/card_border.cljs
+++ b/src/braid/core/client/ui/views/card_border.cljs
@@ -4,10 +4,9 @@
     [braid.core.client.helpers :as helpers]))
 
 (defn card-border-view [thread-id]
-  (let [group-id @(subscribe [:open-group-id])
-        color (helpers/->color group-id)]
+  (let [color (helpers/->color @(subscribe [:open-group-id]))]
     [:div.border
      {:style
       {:background (if @(subscribe [:thread-focused? thread-id])
                      (helpers/darken color)
-                     (helpers/->color color))}}]))
+                     color)}}]))

--- a/src/braid/core/client/ui/views/card_border.cljs
+++ b/src/braid/core/client/ui/views/card_border.cljs
@@ -1,0 +1,13 @@
+(ns braid.core.client.ui.views.card-border
+  (:require
+    [re-frame.core :refer [subscribe]]
+    [braid.core.client.helpers :as helpers]))
+
+(defn card-border-view [thread-id]
+  (let [group-id @(subscribe [:open-group-id])
+        color (helpers/->color group-id)]
+    [:div.border
+     {:style
+      {:background (if @(subscribe [:thread-focused? thread-id])
+                     (helpers/darken color)
+                     (helpers/->color color))}}]))

--- a/src/braid/core/client/ui/views/message.cljs
+++ b/src/braid/core/client/ui/views/message.cljs
@@ -4,6 +4,7 @@
     [braid.core.client.helpers :as helpers :refer [id->color ->color]]
     [braid.core.client.routes :as routes]
     [braid.core.client.ui.views.pills :refer [tag-pill-view user-pill-view]]
+    [braid.core.client.ui.views.card-border :refer [card-border-view]]
     [cljsjs.highlight.langs.clojure]
     [cljsjs.highlight.langs.css]
     [cljsjs.highlight.langs.javascript]
@@ -219,6 +220,9 @@
                                " " (if (:unseen? message) "unseen" "seen")
                                " " (when (:first-unseen? message) "first-unseen")
                                " " (when (:failed? message) "failed-to-send"))}
+
+     [card-border-view (message :thread-id)]
+
      (when (:failed? message)
        [:div.error
         [:span "Message failed to send"]

--- a/src/braid/core/client/ui/views/thread.cljs
+++ b/src/braid/core/client/ui/views/thread.cljs
@@ -322,7 +322,7 @@
             "This is a private conversation." [:br]
             "Only @mentioned users can see it."])
 
-         [:div.card
+         [:div.card {:style {:border-left-color (helpers/->color (thread :group-id))}}
           [thread-header-view thread]
 
           (when-not new?

--- a/src/braid/core/client/ui/views/thread.cljs
+++ b/src/braid/core/client/ui/views/thread.cljs
@@ -8,6 +8,7 @@
    [braid.core.client.helpers :as helpers]
    [braid.core.client.routes :as routes]
    [braid.core.client.s3 :as s3]
+   [braid.core.client.ui.views.card-border :refer [card-border-view]]
    [braid.core.client.ui.views.message :refer [message-view]]
    [braid.core.client.ui.views.new-message :refer [new-message-view]]
    [braid.core.client.ui.views.pills :refer [user-pill-view tag-pill-view]]
@@ -322,7 +323,9 @@
             "This is a private conversation." [:br]
             "Only @mentioned users can see it."])
 
-         [:div.card {:style {:border-left-color (helpers/->color (thread :group-id))}}
+         [:div.card
+          [card-border-view (thread :id)]
+
           [thread-header-view thread]
 
           (when-not new?


### PR DESCRIPTION
![screenshot from 2018-06-14 10-39-51](https://user-images.githubusercontent.com/89664/41401152-5f8c8a5c-6fbf-11e8-8dd8-cfc0c1281554.png)

Cchanged the styling for focused threads. Instead of a thick shadow, the color a border is added on the left. (See screenshot above)

Also changed how unread messages are shown. Previously, read messages had decreased opacity, but this had some legibility issues (and the implementation was hacky). Instead, the new border is used: new messages have a thicker border (as in the screenshot above).
