### PR TITLE
Make "register" button from login page more obvious

### DIFF
--- a/src/braid/core/client/gateway/forms/user_auth/styles.cljs
+++ b/src/braid/core/client/gateway/forms/user_auth/styles.cljs
@@ -16,6 +16,8 @@
       (vars/small-button-mixin)]]
 
     [:.alternative-auth
+     :.switch-to-register-button
+     :.switch-to-login-button
 
      [:h3
       {:margin "3em 0 2em 0"

--- a/src/braid/core/client/gateway/forms/user_auth/views.cljs
+++ b/src/braid/core/client/gateway/forms/user_auth/views.cljs
@@ -129,6 +129,17 @@
    [password-reset-button-view]
    [error-view]])
 
+(defn switch-to-register-button
+  []
+  [:div.switch-to-register-button
+   [:h3 [:span "Don't have an account?"]]
+   [:button
+    {:type "button"
+     :on-click (fn [e]
+                 (.preventDefault e)
+                 (dispatch [:braid.core.client.gateway.forms.user-auth.events/set-mode :register]))}
+    "Register"]])
+
 (defn returning-user-view []
   [form-view
    {:title "Log in to Braid"
@@ -140,18 +151,12 @@
                  {:validate-fields [:email
                                     :password]
                   :dispatch-when-valid [:braid.core.client.gateway.forms.user-auth.events/remote-log-in]}]))}
-   [:p "Don't have an account?"
-    [:button
-     {:type "button"
-      :on-click (fn [e]
-                  (.preventDefault e)
-                  (dispatch [:braid.core.client.gateway.forms.user-auth.events/set-mode :register]))}
-     "Register"]]
    [returning-email-field-view]
    [returning-password-field-view]
    [login-button-view]
    [alternative-auth "Or, log in with"]
-   [error-view]])
+   [error-view]
+   [switch-to-register-button]])
 
 (defn new-password-field-view []
   [field-view
@@ -186,6 +191,17 @@
       :class (when-not fields-valid? "disabled")}
      "Create a Braid Account"]))
 
+(defn switch-to-login-view
+  []
+  [:div.switch-to-login-button
+   [:h3 [:span "Already registered?"]]
+   [:button
+    {:type "button"
+     :on-click (fn [e]
+                 (.preventDefault e)
+                 (dispatch [:braid.core.client.gateway.forms.user-auth.events/set-mode :log-in]))}
+    "Log In"]])
+
 (defn new-user-view []
   [form-view
    {:title "Create a Braid Account"
@@ -197,18 +213,12 @@
                  {:validate-fields [:email
                                     :new-password]
                   :dispatch-when-valid [:braid.core.client.gateway.forms.user-auth.events/remote-register]}]))}
-   [:p "Already have one?"
-    [:button
-     {:type "button"
-      :on-click (fn [e]
-                  (.preventDefault e)
-                  (dispatch [:braid.core.client.gateway.forms.user-auth.events/set-mode :log-in]))}
-     "Log In"]]
    [new-email-field-view]
    [new-password-field-view]
    [register-button-view]
    [alternative-auth "Or, register with"]
-   [error-view]])
+   [error-view]
+   [switch-to-login-view]])
 
 (defn authed-user-view []
   (let [user @(subscribe [:braid.core.client.gateway.forms.user-auth.subs/user])]


### PR DESCRIPTION
The little "register" button in the top corner seems hard for new users to notice - trying to make it more clear that the page is for logging in & that to create a new account, users need to go to the register page.

This uses the same style as the new "alternative login" section.