### PR TITLE
Private messaging from hover cards implemented

### DIFF
--- a/src/braid/core/client/core/events.cljs
+++ b/src/braid/core/client/core/events.cljs
@@ -148,14 +148,9 @@
     (let [message (schema/make-message
                     {:user-id (helpers/current-user-id state)
                      :content ":wave:"
-                     :thread-id (data :thread-id)
                      :group-id (data :group-id)
-                     :mentioned-tag-ids (concat
-                                          (data :mentioned-tag-ids)
-                                          (extract-tag-ids state (data :content)))
-                     :mentioned-user-ids (concat
-                                           (data :mentioned-user-ids)
-                                           (extract-user-ids state (data :content)))})]
+                     :mentioned-tag-ids (data :mentioned-tag-ids)
+                     :mentioned-user-ids (data :mentioned-user-ids)})]
       {:websocket-send
        (list
          [:braid.server/new-message message]

--- a/src/braid/core/client/ui/views/user_hover_card.cljs
+++ b/src/braid/core/client/ui/views/user_hover_card.cljs
@@ -34,10 +34,9 @@
           ; Open a new message with the selected user on click
           [:a.pm
             {:on-click
-              (fn [e]
+              (fn [_]
                 (dispatch [:new-conversation
                             { :group-id @open-group-id
-                              :content ""
                               :mentioned-user-ids [user-id]}]))}
             "PM"]
         #_[:a.mute "Mute"]

--- a/src/braid/core/client/ui/views/user_hover_card.cljs
+++ b/src/braid/core/client/ui/views/user_hover_card.cljs
@@ -35,11 +35,9 @@
           [:a.pm
             {:on-click
               (fn [e]
-                (.preventDefault e)
-                (println "Opening new chat with user: " user-id " in group: " @open-group-id)
-                (dispatch [:new-message
+                (dispatch [:new-conversation
                             { :group-id @open-group-id
-                              :content (str "Hi @" user-id "!")
+                              :content ""
                               :mentioned-user-ids [user-id]}]))}
             "PM"]
         #_[:a.mute "Mute"]

--- a/src/braid/core/client/ui/views/user_hover_card.cljs
+++ b/src/braid/core/client/ui/views/user_hover_card.cljs
@@ -30,7 +30,18 @@
          #_"If I had a profile, it would be here"]]
 
        [:div.actions
-        #_[:a.pm "PM"]
+
+          ; Open a new message with the selected user on click
+          [:a.pm
+            {:on-click
+              (fn [e]
+                (.preventDefault e)
+                (println "Opening new chat with user: " user-id " in group: " @open-group-id)
+                (dispatch [:new-message
+                            { :group-id @open-group-id
+                              :content (str "Hi @" user-id "!")
+                              :mentioned-user-ids [user-id]}]))}
+            "PM"]
         #_[:a.mute "Mute"]
 
         [search-button-view (str "@" (user :nickname))]


### PR DESCRIPTION
## Closes #136 by adding a button with the label `PM` to all user hover cards.

- Hover a user's name while in a conversation and click PM
- Currently populates the message with ':wave:'
- It'd be better if it was blank but there's a restriction on events
- To facilitate this, I created a new event named `:new-conversation`, which simply needs to be given the current group and the targeted user
- Right now, this event sends a :wave: message to the other user, which in turn opens a new thread. In the future it'd be nice to open a conversation *without* sending any messages, in case the button was clicked by mistake
- Hence, making a new event to dispatch will come in handy for when we want to open threads with no content in the future