### PR TITLE
Issue: #135 Add a user administration page (for admins only)

### DIFF
--- a/src/braid/core/client/ui/views/header.cljs
+++ b/src/braid/core/client/ui/views/header.cljs
@@ -66,7 +66,11 @@
    {:class "group-bots"
     :route-fn routes/group-page-path
     :route-args {:page-id "bots"}
-    :body "Bots"}])
+    :body "Bots"}
+   {:class "users"
+    :route-fn routes/group-page-path
+    :route-args {:page-id "users"}
+    :body "Users"}])
 
 (defn admin-header-view []
   (let [user-id (subscribe [:user-id])

--- a/src/braid/core/modules.cljc
+++ b/src/braid/core/modules.cljc
@@ -21,6 +21,7 @@
     [braid.stars.core]
     [braid.uploads.core]
     [braid.uploads-page.core]
+    [braid.users.core]
     [braid.video-embeds.core]
     [braid.website-embeds.core]
     [braid.youtube-embeds.core]
@@ -48,6 +49,7 @@
   (braid.search.core/init!)
   (braid.uploads.core/init!)
   (braid.uploads-page.core/init!)
+  (braid.users.core/init!)
   (braid.video-embeds.core/init!)
   (braid.website-embeds.core/init!)
   (braid.youtube-embeds.core/init!)

--- a/src/braid/users/client/views/users_page.cljs
+++ b/src/braid/users/client/views/users_page.cljs
@@ -5,7 +5,12 @@
 (defn user-view
   [user]
   (let [nickname (:nickname user)]
-    [:tr.user [:td.nickname nickname]]))
+    [:tr.user
+     [:td.nickname nickname]
+     [:td.action [:button.make-admin
+                  {:on-click
+                   (fn [_])}
+                  "Make Admin"]]]))
 
 (defn users-page-view []
   (let [users @(subscribe [:users])]
@@ -23,7 +28,8 @@
         [:table.users
          [:thead
           [:tr
-           [:th "Nickname"]]]
+           [:th "Nickname"]
+           [:th "Action"]]]
          [:tbody
           (doall
            (for [user users]

--- a/src/braid/users/client/views/users_page.cljs
+++ b/src/braid/users/client/views/users_page.cljs
@@ -1,0 +1,5 @@
+(ns braid.users.client.views.users-page)
+
+(defn users-page-view []
+  [:div.page.users
+   [:div.title "Users"]])

--- a/src/braid/users/client/views/users_page.cljs
+++ b/src/braid/users/client/views/users_page.cljs
@@ -21,6 +21,9 @@
 
         :else
         [:table.users
+         [:thead
+          [:tr
+           [:th "Nickname"]]]
          [:tbody
           (doall
            (for [user users]

--- a/src/braid/users/client/views/users_page.cljs
+++ b/src/braid/users/client/views/users_page.cljs
@@ -1,5 +1,28 @@
-(ns braid.users.client.views.users-page)
+(ns braid.users.client.views.users-page
+  (:require
+   [re-frame.core :refer [subscribe]]))
+
+(defn user-view
+  [user]
+  (let [nickname (:nickname user)]
+    [:tr.user [:td.nickname nickname]]))
 
 (defn users-page-view []
-  [:div.page.users
-   [:div.title "Users"]])
+  (let [users @(subscribe [:users])]
+    [:div.page.uploads
+     [:div.title "Users"]
+     [:div.content
+      (cond
+        (nil? users)
+        [:p "Loading..."]
+
+        (empty? users)
+        [:p "No users yet"]
+
+        :else
+        [:table.users
+         [:tbody
+          (doall
+           (for [user users]
+             ^{:key (user :id)}
+             [user-view user]))]])]]))

--- a/src/braid/users/core.cljc
+++ b/src/braid/users/core.cljc
@@ -1,0 +1,12 @@
+(ns braid.users.core
+  (:require
+   [braid.core.api :as core]
+   #?@(:cljs
+       [[braid.users.client.views.users-page :as views]])))
+
+(defn init! []
+  #?(:cljs
+     (do
+       (core/register-group-page!
+        {:key :users
+         :view views/users-page-view}))))

--- a/src/braid/users/core.cljc
+++ b/src/braid/users/core.cljc
@@ -2,11 +2,19 @@
   (:require
    [braid.core.api :as core]
    #?@(:cljs
-       [[braid.users.client.views.users-page :as views]])))
+       [[braid.users.client.views.users-page :as views]
+        [braid.core.client.routes :as routes]])))
+
+
 
 (defn init! []
   #?(:cljs
      (do
        (core/register-group-page!
         {:key :users
-         :view views/users-page-view}))))
+         :view views/users-page-view})
+       (core/register-admin-header-item!
+        {:class "users"
+         :route-fn routes/group-page-path
+         :route-args {:page-id "users"}
+         :body "Users"}))))


### PR DESCRIPTION
- [x] Add a menu item in the admin menu
- [x] Ideally menu item should be a hook
- [x] Create a module for the page
- [x] Read users from state
- [x] List of users with name and "make user an admin" button (as first step)
- [ ] The page should list of users in a table (with their name, last-sign in) and buttons to remove user or make the user an admin. 
- [ ] Later, add the ability to bulk invite users.