### PR TITLE
Ask for confirmation when about to add a tag to a private thread

### DIFF
--- a/src/braid/core/client/core/events.cljs
+++ b/src/braid/core/client/core/events.cljs
@@ -46,6 +46,11 @@
 
 (reg-fx :notify notify/notify)
 
+(reg-fx :confirm (fn [{:keys [prompt on-confirm on-cancel]}]
+                   (if (js/confirm prompt)
+                     (on-confirm)
+                     (when on-cancel (on-cancel)))))
+
 (defn name->open-tag-id
   "Lookup tag by name in the open group"
   [state tag-name]
@@ -167,32 +172,50 @@
 
 (reg-event-fx
   :new-message
-  (fn [{state :db} [_ data]]
+  (fn [{db :db} [_ data]]
     (when-not (string/blank? (data :content))
       (let [message (schema/make-message
-                      {:user-id (helpers/current-user-id state)
-                       :content (identify-mentions state (data :content))
+                      {:user-id (helpers/current-user-id db)
+                       :content (identify-mentions db (data :content))
                        :thread-id (data :thread-id)
                        :group-id (data :group-id)
                        :mentioned-tag-ids (concat
                                             (data :mentioned-tag-ids)
-                                            (extract-tag-ids state (data :content)))
+                                            (extract-tag-ids db (data :content)))
                        :mentioned-user-ids (concat
                                              (data :mentioned-user-ids)
-                                             (extract-user-ids state (data :content)))})]
-        {:websocket-send
-         (list
-           [:braid.server/new-message message]
-           2000
-           (fn [reply]
-             (when (not= :braid/ok reply)
-               (dispatch [:braid.notices/display! [(keyword "failed-to-send" (message :id))
-                                                   "Message failed to send!"
-                                                   :error]])
-               (dispatch [:set-message-failed message]))))
-         :db (-> state
-                 (helpers/add-message message)
-                 (helpers/maybe-reset-temp-thread (data :thread-id)))}))))
+                                             (extract-user-ids db (data :content)))})
+            thread-id (data :thread-id)]
+        (if (and
+              ;; thread already exists...
+              (not= thread-id (get-in db [:temp-threads (db :open-group-id) :id]))
+              ;; doesn't have any tags yet...
+              (empty? (get-in db [:threads thread-id :tag-ids]))
+              ;; about to add a tag
+              (seq (message :mentioned-tag-ids)))
+          {:confirm {:prompt "You're about to make a private thread public"
+                     :on-confirm (fn []
+                                   (when-let [added (data :on-added)] (added))
+                                   (dispatch [::persist-new-message message thread-id]))}}
+          (do (when-let [added (data :on-added)] (added))
+              {:dispatch [::persist-new-message message thread-id]}))))))
+
+(reg-event-fx
+  ::persist-new-message
+  (fn [{state :db} [_ message created-thread-id]]
+    {:websocket-send
+     (list
+       [:braid.server/new-message message]
+       2000
+       (fn [reply]
+         (when (not= :braid/ok reply)
+           (dispatch [:braid.notices/display! [(keyword "failed-to-send" (message :id))
+                                               "Message failed to send!"
+                                               :error]])
+           (dispatch [:set-message-failed message]))))
+     :db (-> state
+             (helpers/add-message message)
+             (helpers/maybe-reset-temp-thread created-thread-id))}))
 
 (reg-event-fx
   :core/retract-message

--- a/src/braid/core/client/ui/views/new_message.cljs
+++ b/src/braid/core/client/ui/views/new_message.cljs
@@ -68,8 +68,8 @@
                              :group-id (config :group-id)
                              :content text
                              :mentioned-user-ids (config :mentioned-user-ids)
-                             :mentioned-tag-ids (config :mentioned-tag-ids)}])
-                 (set-text! ""))})}]])})))
+                             :mentioned-tag-ids (config :mentioned-tag-ids)
+                             :on-added (fn [] (set-text! ""))}]))})}]])})))
 
 (defn autocomplete-results-view [{:keys [results highlighted-result-index on-click]}]
   [:div.autocomplete


### PR DESCRIPTION
Pursuant to #199

Some things to still consider:

 - Currently, this is making the new message text view pass a callback
 to be invoked after it's successfully created, instead of clearing
 the text right away, so that if the user declines the creating, they
 have the ability to edit their message
 - just using js/confirm now, which is pretty ugly & page-modal;
 should probably actually make some UI for this; would also let us not
 block in re-frame.