### PR TITLE
Fix namespace for noembed.clj

### DIFF
--- a/src/braid/lib/noembed.clj
+++ b/src/braid/lib/noembed.clj
@@ -1,8 +1,7 @@
-(ns braid.core.server.api.noembed
-  (:require
-    [clojure.data.json :as json]
-    [org.httpkit.client :as http]
-    [taoensso.timbre :as timbre]))
+(ns braid.lib.noembed
+  (:require [clojure.data.json :as json]
+            [org.httpkit.client :as http]
+            [taoensso.timbre :as timbre]))
 
 (defn get-oembed
   [url]


### PR DESCRIPTION
Uberjar creation, amongst other things, is not happy with the file/namespace mismatch.