### PR TITLE
Cookie store

### DIFF
--- a/src/braid/core/server/core.clj
+++ b/src/braid/core/server/core.clj
@@ -18,12 +18,11 @@
   [server port]
   (run-server server {:port port :legacy-return-value? false}))
 
-(defn start-servers! [opts]
-  (let [wrap (fn [handler] (wrap-universal-middleware handler (opts :middleware)))
-        desktop-port (:port opts)
+(defn start-servers! [{:keys [middleware port]}]
+  (let [wrap (fn [handler] (wrap-universal-middleware handler middleware))
         desktop-server (do
-                         (timbre/debugf "starting desktop server on port %d" desktop-port)
-                         (start-server! (wrap #'desktop-client-app) desktop-port))
+                         (timbre/debugf "starting desktop server on port %d" port)
+                         (start-server! (wrap #'desktop-client-app) port))
         desktop-port (server-port desktop-server)]
     (timbre/debugf "Started desktop server on port %d" desktop-port)
     (let [mobile-port (inc desktop-port)

--- a/src/braid/core/server/core.clj
+++ b/src/braid/core/server/core.clj
@@ -1,5 +1,6 @@
 (ns braid.core.server.core
   (:require
+   [braid.core.server.middleware :refer [wrap-universal-middleware]]
    [braid.core.server.handler :refer [mobile-client-app
                                       desktop-client-app
                                       api-server-app]]
@@ -12,27 +13,24 @@
 
 ;; server
 
-(defn start-server!
-  [type port]
-  (let [app (case type
-              :api #'api-server-app
-              :desktop #'desktop-client-app
-              :mobile #'mobile-client-app)]
-    (run-server app {:port port :legacy-return-value? false})))
+(defn- start-server!
+  [server port]
+  (run-server server {:port port :legacy-return-value? false}))
 
-(defn start-servers! []
-  (let [desktop-port (:port (mount/args))
+(defn start-servers! [opts]
+  (let [wrap (fn [handler] (wrap-universal-middleware handler (opts :middleware)))
+        desktop-port (:port opts)
         desktop-server (do
                          (timbre/debugf "starting desktop server on port %d" desktop-port)
-                         (start-server! :desktop desktop-port))
+                         (start-server! (wrap #'desktop-client-app) desktop-port))
         desktop-port (server-port desktop-server)]
     (timbre/debugf "Started desktop server on port %d" desktop-port)
     (let [mobile-port (inc desktop-port)
           api-port (inc mobile-port)
           mobile-server (do (timbre/debugf "starting mobile server on port %d" mobile-port)
-                            (start-server! :mobile mobile-port))
+                            (start-server! (wrap #'mobile-client-app) mobile-port))
           api-server (do (timbre/debugf "starting api server on port %d" api-port)
-                         (start-server! :api api-port))]
+                         (start-server! (wrap #'api-server-app) api-port))]
       {:desktop desktop-server
        :mobile mobile-server
        :api api-server})))
@@ -44,7 +42,7 @@
     @(server-stop! srv {:timeout 100})))
 
 (defstate servers
-  :start (start-servers!)
+  :start (start-servers! (mount/args))
   :stop (stop-servers! servers))
 
 ;; exceptions in background thread handler

--- a/src/braid/core/server/handler.clj
+++ b/src/braid/core/server/handler.clj
@@ -19,7 +19,8 @@
       (assoc-in [:security :anti-forgery] true)))
 
 (def static-site-defaults
-  {:params {:urlencoded true
+  {:session false
+   :params {:urlencoded true
             :multipart  true
             :nested     true
             :keywordize true}
@@ -44,24 +45,32 @@
 
        (-> api-public-routes
            (wrap-defaults (-> site-defaults
+                              (assoc :session false)
                               (assoc-in [:security :anti-forgery] false))))
 
        (-> modules/public-handler
            (wrap-defaults (-> site-defaults
+                              (assoc :session false)
                               (assoc-in [:security :anti-forgery] false)))
            (wrap-restful-format :formats [:edn :transit-json]))
 
        (-> sync-routes
-           (wrap-defaults (-> api-defaults assoc-csrf-conf)))
+           (wrap-defaults (-> api-defaults
+                              (assoc :session false)
+                              assoc-csrf-conf)))
 
        (-> api-private-routes
-           (wrap-defaults (-> api-defaults assoc-csrf-conf)))
+           (wrap-defaults (-> api-defaults
+                              (assoc :session false)
+                              assoc-csrf-conf)))
 
        ;; this needs to be last, because the middleware will return
        ;; 401 if not authorized & hence not fall-through to other
        ;; routes
        (-> modules/private-handler
-           (wrap-defaults (-> site-defaults assoc-csrf-conf))
+           (wrap-defaults (-> site-defaults
+                              (assoc :session false)
+                              assoc-csrf-conf))
            (wrap-restful-format :formats [:edn :transit-json])))
       (wrap-cors :access-control-allow-origin (->>
                                                [(when-let [site (env :site-url)]

--- a/src/braid/core/server/handler.clj
+++ b/src/braid/core/server/handler.clj
@@ -72,5 +72,4 @@
                                                (remove nil?))
                  :access-control-allow-credentials true
                  :access-control-allow-methods [:get :put :post :delete])
-      wrap-edn-params
-      (wrap-universal-middleware {:session session-config})))
+      wrap-edn-params))

--- a/src/braid/core/server/handler.clj
+++ b/src/braid/core/server/handler.clj
@@ -18,6 +18,9 @@
   (-> defaults
       (assoc-in [:security :anti-forgery] true)))
 
+;; Here we define handlers for the various servers and subsets of the routes.  To allow late-binding/run-time configuration, we
+;; intentionally excise some middleware (e.g. session handling) from the ring default middleware configurations, sometimes even excising
+;; such middleware where it might not be included by default.
 (def static-site-defaults
   {:session false
    :params {:urlencoded true

--- a/src/braid/core/server/handler.clj
+++ b/src/braid/core/server/handler.clj
@@ -12,6 +12,7 @@
    [ring.middleware.defaults :refer [wrap-defaults api-defaults secure-site-defaults site-defaults]]
    [ring.middleware.format :refer [wrap-restful-format]]
    [ring.middleware.edn :refer [wrap-edn-params]]
+   [ring.middleware.session :refer [wrap-session]]
    [taoensso.timbre :as timbre]))
 
 (def session-max-age (* 60 60 24 365))
@@ -31,19 +32,6 @@
     (let [cookie-store (ns-resolve 'ring.middleware.session.cookie 'cookie-store)]
       (def session-store (cookie-store)))))
 
-(defn assoc-cookie-conf [defaults]
-  (-> defaults
-      (assoc-in [:session :cookie-name] "braid")
-      (assoc-in [:session :cookie-attrs :secure] (cond
-                                                   (env :http-only)
-                                                   false
-                                                   (= (env :environment) "prod")
-                                                   true
-                                                   :else
-                                                   false))
-      (assoc-in [:session :cookie-attrs :max-age] session-max-age)
-      (assoc-in [:session :store] session-store)))
-
 (defn assoc-csrf-conf [defaults]
   (-> defaults
       (assoc-in [:security :anti-forgery] true)))
@@ -58,6 +46,15 @@
                :content-types          true
                :default-charset        "utf-8"}})
 
+(def session-config
+  {:cookie-name "braid",
+   :cookie-attrs {:secure (cond
+                            (env :http-only) false
+                            (= (env :environment) "prod") true
+                            :else false)
+                  :max-age session-max-age},
+   :store session-store})
+
 (defn- wrap-log-requests
   [handler]
   (fn [{uri :uri method :request-method :as request}]
@@ -66,62 +63,57 @@
       (timbre/debugf "[%s +%4dms] %8.8s %s" status (- (System/currentTimeMillis) t0) method uri)
       response)))
 
-(def mobile-client-app
-  (-> (routes
-       resource-routes
-       mobile-client-routes)
-      (wrap-defaults (-> static-site-defaults
-                         assoc-cookie-conf))
+;; Here we define universal (as opposed to route-specific) middleware.
+(defn- wrap-universal-middleware
+  "Wrap the handler with middleware that is universally applicable across the site."
+  [handler options]
+  (-> handler
+      (wrap-session (options :session))
       wrap-log-requests))
 
+(def mobile-client-app
+  (-> (routes resource-routes mobile-client-routes)
+      (wrap-defaults static-site-defaults)
+      (wrap-universal-middleware {:session session-config})))
+
 (def desktop-client-app
-  (-> (routes
-       resource-routes
-       desktop-client-routes)
-      (wrap-defaults (-> static-site-defaults
-                         assoc-cookie-conf))
-      wrap-log-requests))
+  (-> (routes resource-routes desktop-client-routes)
+      (wrap-defaults static-site-defaults)
+      (wrap-universal-middleware {:session session-config})))
 
 (def api-server-app
   (-> (routes
-        modules/raw-handlers
+       modules/raw-handlers
 
-        (-> api-public-routes
-            (wrap-defaults (-> site-defaults
-                               (assoc-in [:security :anti-forgery] false)
-                               assoc-cookie-conf)))
+       (-> api-public-routes
+           (wrap-defaults (-> site-defaults
+                              (assoc-in [:security :anti-forgery] false))))
 
-        (-> modules/public-handler
-            (wrap-defaults (-> site-defaults
-                               (assoc-in [:security :anti-forgery] false)))
-            (wrap-restful-format :formats [:edn :transit-json]))
+       (-> modules/public-handler
+           (wrap-defaults (-> site-defaults
+                              (assoc-in [:security :anti-forgery] false)))
+           (wrap-restful-format :formats [:edn :transit-json]))
 
-        (-> sync-routes
-            (wrap-defaults (-> api-defaults
-                               assoc-cookie-conf
-                               assoc-csrf-conf)))
+       (-> sync-routes
+           (wrap-defaults (-> api-defaults assoc-csrf-conf)))
 
        (-> api-private-routes
-            (wrap-defaults (-> api-defaults
-                               assoc-cookie-conf
-                               assoc-csrf-conf)))
+           (wrap-defaults (-> api-defaults assoc-csrf-conf)))
 
        ;; this needs to be last, because the middleware will return
        ;; 401 if not authorized & hence not fall-through to other
        ;; routes
        (-> modules/private-handler
-           (wrap-defaults (-> site-defaults
-                              assoc-cookie-conf
-                              assoc-csrf-conf))
+           (wrap-defaults (-> site-defaults assoc-csrf-conf))
            (wrap-restful-format :formats [:edn :transit-json])))
       (wrap-cors :access-control-allow-origin (->>
-                                                [(when-let [site (env :site-url)]
-                                                   (re-pattern (java.util.regex.Pattern/quote site)))
-                                                 (when-let [mobile-site (env :mobile-site-url)]
-                                                   (re-pattern (java.util.regex.Pattern/quote mobile-site)))
-                                                 #"http://localhost:\d+"]
-                                                  (remove nil?))
+                                               [(when-let [site (env :site-url)]
+                                                  (re-pattern (java.util.regex.Pattern/quote site)))
+                                                (when-let [mobile-site (env :mobile-site-url)]
+                                                  (re-pattern (java.util.regex.Pattern/quote mobile-site)))
+                                                #"http://localhost:\d+"]
+                                               (remove nil?))
                  :access-control-allow-credentials true
                  :access-control-allow-methods [:get :put :post :delete])
       wrap-edn-params
-      wrap-log-requests))
+      (wrap-universal-middleware {:session session-config})))

--- a/src/braid/core/server/middleware.clj
+++ b/src/braid/core/server/middleware.clj
@@ -41,7 +41,7 @@
 ;; Here we define the universal (as opposed to route-specific) middleware stack.
 (defn wrap-universal-middleware
   "Wrap the handler with middleware that is universally applicable across the site."
-  [handler {:keys [session] :or {session session-config}}]
+  [handler {:keys [session]}]
   (-> handler
-      (wrap-session session)
+      (wrap-session (or session session-config))
       wrap-log-requests))

--- a/src/braid/core/server/middleware.clj
+++ b/src/braid/core/server/middleware.clj
@@ -1,0 +1,47 @@
+(ns braid.core.server.middleware
+  (:require
+   [environ.core :refer [env]]
+   [ring.middleware.session :refer [wrap-session]]
+   [taoensso.timbre :as timbre]))
+
+(def session-max-age (* 60 60 24 365))
+
+;; NOT using config here, b/c it won't have started when this runs
+(if (env :redis-uri)
+  (do
+    (require 'taoensso.carmine.ring)
+    (def ^:dynamic *redis-conf* {:pool {}
+                                 :spec {:uri (env :redis-uri)}})
+    (let [carmine-store (ns-resolve 'taoensso.carmine.ring 'carmine-store)]
+      (def session-store
+        (carmine-store '*redis-conf* {:expiration-secs session-max-age
+                                      :key-prefix "braid"}))))
+  (do
+    (require 'ring.middleware.session.cookie)
+    (let [cookie-store (ns-resolve 'ring.middleware.session.cookie 'cookie-store)]
+      (def session-store (cookie-store)))))
+
+(def session-config
+  {:cookie-name "braid",
+   :cookie-attrs {:secure (cond
+                            (env :http-only) false
+                            (= (env :environment) "prod") true
+                            :else false)
+                  :max-age session-max-age},
+   :store session-store})
+
+(defn- wrap-log-requests
+  [handler]
+  (fn [{uri :uri method :request-method :as request}]
+    (let [t0 (System/currentTimeMillis)
+          {:keys [status] :as response} (handler request)]
+      (timbre/debugf "[%s +%4dms] %8.8s %s" status (- (System/currentTimeMillis) t0) method uri)
+      response)))
+
+;; Here we define the universal (as opposed to route-specific) middleware stack.
+(defn wrap-universal-middleware
+  "Wrap the handler with middleware that is universally applicable across the site."
+  [handler {:keys [session] :or {session session-config}}]
+  (-> handler
+      (wrap-session session)
+      wrap-log-requests))

--- a/test/helpers/cookies.clj
+++ b/test/helpers/cookies.clj
@@ -1,0 +1,43 @@
+(ns helpers.cookies
+  (:require
+   [ring.util.codec :as codec]
+   [clojure.string :as string])
+  (:import
+   (java.time Instant)
+   (java.time.format DateTimeFormatter)))
+
+(let [parser DateTimeFormatter/RFC_1123_DATE_TIME]
+  (defn- parse-rfc1123 [s]
+    "Parse RFC822/RFC1123 date per http://tools.ietf.org/html/rfc2616#section-3.3.1"
+    (.. parser (parseDateTime s) getMillis)))
+
+(let [matchers [#(when-let [match (re-find #"Max-Age=(\d+)" %)]
+                   [:max-age (.. Instant now (plusMillis (long (* 1000 (Integer/parseInt (match 1))))) toEpochMilli)])
+                #(when-let [match (re-find #"Expires=(.+)" %)]
+                   [:expires (parse-rfc1123 (match 1))])
+                #(when-let [match (re-find #"Domain=(.+)" %)]
+                   [:domain (match 1)])
+                #(when-let [match (re-find #"Path=(.*)" %)]
+                   [:path (match 1)])
+                #(when (= "Secure" %) [:secure true])
+                #(when (= "HttpOnly" %) [:http-only true])]]
+
+  (defn- parse-cookie-attrs [attr-string]
+    "Parse optional cookie attributes per RFC 6265"
+    (let [attrs (string/split attr-string #";")
+          matches (map (fn [a] (some (fn [m] (m a)) matchers)) attrs)]
+      ;; max-age dominates expires
+      (reduce (fn [m [k v]] (if (= :max-age k) (merge {:expires v} m) (merge m {k v}))) {} matches))))
+
+(defn parse-cookie [c]
+  "Parse cookies per http://tools.ietf.org/html/rfc6265"
+  (let [x (re-find #"([^;]+)(?:;(.*))*" c)
+        [name value] (first (codec/form-decode (x 1)))
+        av-map (parse-cookie-attrs (x 2))]
+    {name (merge av-map {:value value})}))
+
+(defn write-cookie [[name {value :value}]]
+  (codec/form-encode {name value}))
+
+(defn write-cookies [cookies]
+  (string/join ";" (map write-cookie cookies)))

--- a/test/unit/braid/core/server/middleware_test.clj
+++ b/test/unit/braid/core/server/middleware_test.clj
@@ -1,0 +1,34 @@
+(ns unit.braid.core.server.middleware-test
+  (:require
+   [braid.core.server.middleware :refer :all]
+   [ring.middleware.session.cookie :refer [cookie-store]]
+   [helpers.cookies :refer [write-cookies parse-cookie]]
+   [clojure.test :refer :all]))
+
+(deftest can-wrap-handler
+  (is (fn? (wrap-universal-middleware identity {}))))
+
+(defmulti handler :uri)
+(defmethod handler "/read" [{session :session}] {:status 200 :session' session})
+(defmethod handler "/write" [_] {:status 200 :session {:message "Claude E. Shannon"}})
+
+(deftest default-session-store-is-persistent
+  (let [handler (wrap-universal-middleware handler {})
+        request {:uri "/write"}
+        response (handler request)
+        cookies (reduce merge (map parse-cookie (get-in response [:headers "Set-Cookie"])))
+        request {:uri "/read" :headers {"cookie" (write-cookies cookies)}}]
+    (is (= {:message "Claude E. Shannon"} ((handler request) :session')))))
+
+(deftest custom-session-config-can-be-specified
+  (let [key "0123456789012345"
+        session-options {:name "session" :secure true :maxage 100000 :store (cookie-store {:key key})}
+        handler (wrap-universal-middleware handler {:session session-options})
+        request {:uri "/write"}
+        response (handler request)
+        cookies (reduce merge (map parse-cookie (get-in response [:headers "Set-Cookie"])))]
+    ;; imagine the server restarts...session management configuration is reconstituted...client retains cookies...
+    (let [session-options (assoc session-options :store (cookie-store {:key "0123456789012345"}))
+          handler (wrap-universal-middleware handler {:session session-options})
+          request {:uri "/read" :headers {"cookie" (write-cookies cookies)}}]
+      (is (= {:message "Claude E. Shannon"} ((handler request) :session'))))))


### PR DESCRIPTION
This PR allows `mount/with-args` to convey a custom session configuration to `braid.core.server.core`.  It also extracts common middleware to a new `braid.core.server.middleware` namespace and adds related unit tests.

This is the best way I can find to configure a cookie session store with a constant secret that doesn't compound the early binding/static configuration challenges of `environ`.