### PR TITLE
Remove global environ

### DIFF
--- a/dev-src/braid/dev/core.clj
+++ b/dev-src/braid/dev/core.clj
@@ -1,16 +1,17 @@
 (ns braid.dev.core
   "Starting namespace for Braid REPL. Utilities for dev."
   (:require
-    [mount.core :as mount]
-    [braid.base.server.seed :as seed]
-    [braid.core.modules :as modules]
-    [braid.base.conf :refer [config]]
-    [braid.chat.seed :as chat.seed]
-    [datomic.api :as d]
-    [braid.core.server.db :as db]
-    ; the following namespaces are required for their mount components:
-    [braid.core]
-    [braid.dev.figwheel]))
+   [braid.base.conf :refer [config]]
+   [braid.base.server.seed :as seed]
+   [braid.chat.seed :as chat.seed]
+   [braid.core.modules :as modules]
+   [braid.core.server.db :as db]
+   [datomic.api :as d]
+   [mount.core :as mount]
+   [environ.core :refer [env]]
+   ;; the following namespaces are required for their mount components:
+   [braid.core]
+   [braid.dev.figwheel]))
 
 (defn drop-db!
   "Drops the database (and also the database connection).
@@ -38,7 +39,7 @@
   ;; modules must run first
   (modules/init! modules/default)
   (-> (mount/except #{#'braid.core.server.email-digest/email-jobs})
-      (mount/with-args {:port port})
+      (mount/with-args (assoc env :port port))
       (mount/start))
   (when (zero? port)
     (mount/stop #'braid.base.conf/config)

--- a/src/braid/base/conf.clj
+++ b/src/braid/base/conf.clj
@@ -5,6 +5,9 @@
    [environ.core :refer [env]]
    [mount.core :as mount :refer [defstate]]))
 
+(when (and (= (env :environment) "prod") (empty? (env :hmac-secret)))
+  (println "WARNING: No :hmac-secret set, using an insecure default."))
+
 (defonce config-vars
   (hooks/register! (atom []) [keyword?]))
 

--- a/src/braid/base/conf.clj
+++ b/src/braid/base/conf.clj
@@ -2,11 +2,7 @@
   (:require
    [braid.base.conf-extra :refer [ports-config]]
    [braid.core.hooks :as hooks]
-   [environ.core :refer [env]]
    [mount.core :as mount :refer [defstate]]))
-
-(when (and (= (env :environment) "prod") (empty? (env :hmac-secret)))
-  (println "WARNING: No :hmac-secret set, using an insecure default."))
 
 (defonce config-vars
   (hooks/register! (atom []) [keyword?]))
@@ -21,4 +17,4 @@
      :site-url (str "http://localhost:" (:port (mount/args)))
      :hmac-secret "secret"}
     @ports-config ; overrides api-domain & site url when port is automatically found
-    (select-keys env @config-vars)))
+    (select-keys (mount/args) @config-vars)))

--- a/src/braid/base/server/cache.clj
+++ b/src/braid/base/server/cache.clj
@@ -1,13 +1,14 @@
 (ns braid.base.server.cache
   (:require
-   [environ.core :refer [env]]
+   [braid.base.conf :as conf]
    [taoensso.carmine :as car]))
 
 ; same as conf in handler, but w/e
-(def redis-conn {:pool {}
-                 :spec {:uri (env :redis-uri)}})
+(def redis-conn (delay
+                  {:pool {}
+                   :spec {:uri (conf/config :redis-uri)}}))
 
-(def redis? (env :redis-uri))
+(def redis? (delay (conf/config :redis-uri)))
 
 (def dev-cache
   "Cache used in place of redis when running in dev/demo mode"
@@ -15,16 +16,15 @@
 
 (defn cache-set! [k v]
   (if redis?
-    (car/wcar redis-conn (car/set k v))
+    (car/wcar @redis-conn (car/set k v))
     (swap! dev-cache assoc k v)))
 
 (defn cache-get [k]
-  (if redis?
-    (car/wcar redis-conn (car/get k))
+  (if @redis?
+    (car/wcar @redis-conn (car/get k))
     (@dev-cache k)))
 
 (defn cache-del! [k]
-  (if redis?
-    (car/wcar redis-conn (car/del k))
+  (if @redis?
+    (car/wcar @redis-conn (car/del k))
     (swap! dev-cache dissoc k)))
-

--- a/src/braid/chat/core.cljc
+++ b/src/braid/chat/core.cljc
@@ -33,9 +33,9 @@
        (doseq [k [:api-domain
                   :asana-client-id
                   :asana-client-secret
+                  :aws-access-key
                   :aws-bucket
                   :aws-region
-                  :aws-access-key
                   :aws-secret-key
                   :db-url
                   :embedly-key
@@ -43,8 +43,11 @@
                   :github-client-id
                   :github-client-secret
                   :hmac-secret
+                  :http-only
                   :mailgun-domain
                   :mailgun-password
+                  :mobile-site-url
+                  :redis-uri
                   :site-url]]
          (base/register-config-var! k))
 

--- a/src/braid/chat/server/initial_data.clj
+++ b/src/braid/chat/server/initial_data.clj
@@ -1,12 +1,12 @@
 (ns braid.chat.server.initial-data
   (:require
-    [environ.core :refer [env]]
+    [braid.base.conf :as conf]
     [braid.base.server.socket :refer [connected-uids]]
     [braid.chat.db.group :as group]
-    [braid.chat.db.thread :as thread]
-    [braid.chat.db.tag :as tag]
-    [braid.chat.db.user :as user]
     [braid.chat.db.invitation :as invitation]
+    [braid.chat.db.tag :as tag]
+    [braid.chat.db.thread :as thread]
+    [braid.chat.db.user :as user]
     [braid.lib.digest :as digest]))
 
 (defn initial-data-for-user
@@ -21,7 +21,7 @@
     {;; TODO could be part of braid.base
      :user-id user-id
      ;; TODO could be part of braid.base:
-     :version-checksum (if (= "prod" (env :environment))
+     :version-checksum (if (= "prod" (conf/config :environment))
                          (digest/from-file "public/js/prod/desktop.js")
                          (digest/from-file "public/js/dev/desktop.js"))
      :user-groups
@@ -40,4 +40,3 @@
      :user-preferences (user/user-get-preferences user-id)
      :invitations (invitation/invites-for-user user-id)
      :tags (tag/tags-for-user user-id)}))
-

--- a/src/braid/core/server/handler.clj
+++ b/src/braid/core/server/handler.clj
@@ -8,8 +8,6 @@
    [braid.base.server.http-client-routes :refer [resource-routes]]
    [braid.core.server.routes.socket :refer [sync-routes]]
    [compojure.core :refer [routes context]]
-   [environ.core :refer [env]]
-   [ring.middleware.cors :refer [wrap-cors]]
    [ring.middleware.defaults :refer [wrap-defaults api-defaults secure-site-defaults site-defaults]]
    [ring.middleware.format :refer [wrap-restful-format]]
    [ring.middleware.edn :refer [wrap-edn-params]]))
@@ -34,13 +32,11 @@
 
 (def mobile-client-app
   (-> (routes resource-routes mobile-client-routes)
-      (wrap-defaults static-site-defaults)
-      (wrap-universal-middleware {:session session-config})))
+      (wrap-defaults static-site-defaults)))
 
 (def desktop-client-app
   (-> (routes resource-routes desktop-client-routes)
-      (wrap-defaults static-site-defaults)
-      (wrap-universal-middleware {:session session-config})))
+      (wrap-defaults static-site-defaults)))
 
 (def api-server-app
   (-> (routes
@@ -75,13 +71,4 @@
                               (assoc :session false)
                               assoc-csrf-conf))
            (wrap-restful-format :formats [:edn :transit-json])))
-      (wrap-cors :access-control-allow-origin (->>
-                                               [(when-let [site (env :site-url)]
-                                                  (re-pattern (java.util.regex.Pattern/quote site)))
-                                                (when-let [mobile-site (env :mobile-site-url)]
-                                                  (re-pattern (java.util.regex.Pattern/quote mobile-site)))
-                                                #"http://localhost:\d+"]
-                                               (remove nil?))
-                 :access-control-allow-credentials true
-                 :access-control-allow-methods [:get :put :post :delete])
       wrap-edn-params))

--- a/src/braid/core/server/invite.clj
+++ b/src/braid/core/server/invite.clj
@@ -8,14 +8,10 @@
    [clj-time.core :as t]
    [clojure.string :as string]
    [cljstache.core :as cljstache]
-   [environ.core :refer [env]]
    [image-resizer.core :as img]
    [image-resizer.format :as img-format]
    [org.httpkit.client :as http]
    [taoensso.timbre :as timbre]))
-
-(when (and (= (env :environment) "prod") (empty? (env :hmac-secret)))
-  (println "WARNING: No :hmac-secret set, using an insecure default."))
 
 (defn verify-hmac
   [mac data]

--- a/src/braid/core/server/middleware.clj
+++ b/src/braid/core/server/middleware.clj
@@ -1,41 +1,45 @@
 (ns braid.core.server.middleware
   (:require
-   [environ.core :refer [env]]
+   [braid.base.conf :refer [config]]
+   [mount.core :as mount :refer [defstate]]
+   [ring.middleware.cors :refer [wrap-cors]]
    [ring.middleware.session :refer [wrap-session]]
    [taoensso.timbre :as timbre]))
 
 (def session-max-age (* 60 60 24 365))
 
-;; NOT using config here, b/c it won't have started when this runs
-(if (env :redis-uri)
-  (do
-    (require 'taoensso.carmine.ring)
-    (def ^:dynamic *redis-conf* {:pool {}
-                                 :spec {:uri (env :redis-uri)}})
-    (let [carmine-store (ns-resolve 'taoensso.carmine.ring 'carmine-store)]
-      (def session-store
-        (carmine-store '*redis-conf* {:expiration-secs session-max-age
-                                      :key-prefix "braid"}))))
-  (do
-    (require 'ring.middleware.session.cookie)
-    (let [cookie-store (ns-resolve 'ring.middleware.session.cookie 'cookie-store)]
-      (def session-store (cookie-store)))))
+(def session-store
+  (delay
+    (if (config :redis-uri)
+      (do
+        (require 'taoensso.carmine.ring)
+        (let [carmine-store (ns-resolve 'taoensso.carmine.ring 'carmine-store)
+              redis-conf {:pool {}
+                          :spec {:uri (config :redis-uri)}} ]
+          (carmine-store redis-conf {:expiration-secs session-max-age
+                                     :key-prefix "braid"})))
+      (do
+        (require 'ring.middleware.session.cookie)
+        (let [cookie-store (ns-resolve 'ring.middleware.session.cookie
+                                       'cookie-store)]
+          (cookie-store))))))
 
 (def session-config
-  {:cookie-name "braid",
-   :cookie-attrs {:secure (cond
-                            (env :http-only) false
-                            (= (env :environment) "prod") true
-                            :else false)
-                  :max-age session-max-age},
-   :store session-store})
+  (delay {:cookie-name "braid",
+          :cookie-attrs {:secure (cond
+                                   (config :http-only) false
+                                   (= (config :environment) "prod") true
+                                   :else false)
+                         :max-age session-max-age},
+          :store @session-store}))
 
 (defn- wrap-log-requests
   [handler]
   (fn [{uri :uri method :request-method :as request}]
     (let [t0 (System/currentTimeMillis)
           {:keys [status] :as response} (handler request)]
-      (timbre/debugf "[%s +%4dms] %8.8s %s" status (- (System/currentTimeMillis) t0) method uri)
+      (timbre/debugf "[%s +%4dms] %8.8s %s"
+                     status (- (System/currentTimeMillis) t0) method uri)
       response)))
 
 ;; Here we define the universal (as opposed to route-specific) middleware stack.
@@ -43,5 +47,15 @@
   "Wrap the handler with middleware that is universally applicable across the site."
   [handler {:keys [session]}]
   (-> handler
-      (wrap-session (or session session-config))
+      (wrap-cors :access-control-allow-origin
+                 (->>
+                   [(when-let [site (config :site-url)]
+                      (re-pattern (java.util.regex.Pattern/quote site)))
+                    (when-let [mobile-site (config :mobile-site-url)]
+                      (re-pattern (java.util.regex.Pattern/quote mobile-site)))
+                    #"http://localhost:\d+"]
+                   (remove nil?))
+                 :access-control-allow-credentials true
+                 :access-control-allow-methods [:get :put :post :delete])
+      (wrap-session (or session @session-config))
       wrap-log-requests))

--- a/src/braid/core/server/middleware.clj
+++ b/src/braid/core/server/middleware.clj
@@ -1,7 +1,6 @@
 (ns braid.core.server.middleware
   (:require
    [braid.base.conf :refer [config]]
-   [mount.core :as mount :refer [defstate]]
    [ring.middleware.cors :refer [wrap-cors]]
    [ring.middleware.session :refer [wrap-session]]
    [taoensso.timbre :as timbre]))


### PR DESCRIPTION
Pursuant to prior discussion with @cch1 and @rafd.

This change makes it so environ is just used to provide default arguments to mount, which the conf namespace now uses instead of accessing env directly. This now also allows passing in args explicitly to `braid.core/start!` which will be used instead of env.

Thoughts? If all good, I will merge this in.