### PR TITLE
Aws credentials provider support

### DIFF
--- a/dev-src/braid/dev/core.clj
+++ b/dev-src/braid/dev/core.clj
@@ -39,7 +39,10 @@
   ;; modules must run first
   (modules/init! modules/default)
   (-> (mount/except #{#'braid.core.server.email-digest/email-jobs})
-      (mount/with-args (assoc env :port port))
+      (mount/with-args (cond-> (assoc env :port port)
+                         (env :aws-access-key)
+                         (assoc :aws/credentials-provider
+                                (constantly ((juxt :aws-access-key :aws-secret-key) env)))))
       (mount/start))
   (when (zero? port)
     (mount/stop #'braid.base.conf/config)

--- a/src/braid/base/server/spa.clj
+++ b/src/braid/base/server/spa.clj
@@ -32,9 +32,7 @@
               :basejs (when prod-js?
                         (str (digest/from-file (str "public/js/prod/base.js"))))
               :api_domain (config :api-domain)
-              :asset_domain (s3/s3-host
-                              {:bucket (config :aws-bucket)
-                               :region (config :aws-region)})
+              :asset_domain (s3/s3-host config)
               :extra_scripts
               (->> @additional-scripts
                    (map (fn [s] (if (fn? s) (s) s)))

--- a/src/braid/chat/core.cljc
+++ b/src/braid/chat/core.cljc
@@ -37,6 +37,7 @@
                   :aws-bucket
                   :aws-region
                   :aws-secret-key
+                  :aws/credentials-provider
                   :db-url
                   :embedly-key
                   :environment

--- a/src/braid/chat/core.cljc
+++ b/src/braid/chat/core.cljc
@@ -1,28 +1,28 @@
 (ns braid.chat.core
   "The majority of the core 'chat' functionality of Braid"
   (:require
-    [braid.base.api :as base]
-    [braid.chat.api :as chat]
-    #?@(:clj
-         [[braid.chat.schema :as schema]
-          [braid.chat.seed :as seed]
-          [braid.chat.server.initial-data :as initial-data]]
-        :cljs
-         [[re-frame.core :refer [dispatch]]
-          [braid.chat.client.remote-handlers]
-          [braid.core.client.ui.views.autocomplete]
-          [braid.core.client.store]
-          [braid.popovers.api :as popovers]
-          [braid.core.client.schema :as schema]
-          [braid.core.client.state.helpers :as helpers :refer [key-by-id]]
-          [braid.core.client.ui.styles.hover-menu]
-          [braid.core.client.ui.styles.hover-cards]
-          [braid.core.client.ui.styles.thread]
-          [braid.core.client.ui.views.pages.global-settings :refer [global-settings-page-view]]
-          [braid.core.client.invites.views.invite-page :refer [invite-page-view]]
-          [braid.core.client.ui.views.pages.changelog :refer [changelog-view]]
-          [braid.core.client.ui.views.pages.me :refer [me-page-view]]
-          [braid.core.client.group-admin.views.group-settings-page :refer [group-settings-page-view]]])))
+   [braid.base.api :as base]
+   [braid.chat.api :as chat]
+   #?@(:clj
+       [[braid.chat.schema :as schema]
+        [braid.chat.seed :as seed]
+        [braid.chat.server.initial-data :as initial-data]]
+       :cljs
+       [[re-frame.core :refer [dispatch]]
+        [braid.chat.client.remote-handlers]
+        [braid.core.client.ui.views.autocomplete]
+        [braid.core.client.store]
+        [braid.popovers.api :as popovers]
+        [braid.core.client.schema :as schema]
+        [braid.core.client.state.helpers :as helpers :refer [key-by-id]]
+        [braid.core.client.ui.styles.hover-menu]
+        [braid.core.client.ui.styles.hover-cards]
+        [braid.core.client.ui.styles.thread]
+        [braid.core.client.ui.views.pages.global-settings :refer [global-settings-page-view]]
+        [braid.core.client.invites.views.invite-page :refer [invite-page-view]]
+        [braid.core.client.ui.views.pages.changelog :refer [changelog-view]]
+        [braid.core.client.ui.views.pages.me :refer [me-page-view]]
+        [braid.core.client.group-admin.views.group-settings-page :refer [group-settings-page-view]]])))
 
 (defn init! []
   #?(:clj
@@ -58,66 +58,66 @@
      (do
        (braid.chat.client.remote-handlers/init!)
        (chat/register-autocomplete-engine!
-         braid.core.client.ui.views.autocomplete/user-autocomplete-engine)
+        braid.core.client.ui.views.autocomplete/user-autocomplete-engine)
 
        (chat/register-autocomplete-engine!
-         braid.core.client.ui.views.autocomplete/tag-autocomplete-engine)
+        braid.core.client.ui.views.autocomplete/tag-autocomplete-engine)
 
        (base/register-state! braid.core.client.store/initial-state
                              braid.core.client.store/AppState)
 
        (popovers/register-popover-styles!
-         braid.core.client.ui.styles.hover-cards/>user-card)
+        braid.core.client.ui.styles.hover-cards/>user-card)
 
        (popovers/register-popover-styles!
-         braid.core.client.ui.styles.hover-cards/>tag-card)
+        braid.core.client.ui.styles.hover-cards/>tag-card)
 
        (popovers/register-popover-styles!
-         (braid.core.client.ui.styles.hover-menu/>hover-menu))
+        (braid.core.client.ui.styles.hover-menu/>hover-menu))
 
        (popovers/register-popover-styles!
-         braid.core.client.ui.styles.thread/add-tag-popover-styles)
+        braid.core.client.ui.styles.thread/add-tag-popover-styles)
 
        (base/register-system-page!
-         {:key :global-settings
-          :view global-settings-page-view})
+        {:key :global-settings
+         :view global-settings-page-view})
 
        (base/register-initial-user-data-handler!
-         (fn [db data]
-           (-> db
-               (assoc :session {:user-id (data :user-id)})
-               (assoc-in [:user :subscribed-tag-ids]
-                 (set (data :user-subscribed-tag-ids)))
-               (assoc :groups (key-by-id (data :user-groups)))
-               (assoc :invitations (data :invitations))
-               (assoc :threads (key-by-id (data :user-threads)))
-               (assoc :group-threads
-                 (into {}
-                       (map (fn [[g t]] [g (into #{} (map :id) t)]))
-                       (group-by :group-id (data :user-threads))))
-               (assoc-in [:user :open-thread-ids]
-                 (set (map :id (data :user-threads))))
-               (assoc :temp-threads (->> (data :user-groups)
-                                         (map :id)
-                                         (reduce (fn [memo group-id]
-                                                   (->> (schema/make-temp-thread group-id)
-                                                        (assoc memo group-id)))
-                                                 {})))
-               (helpers/add-tags (data :tags))
-               (helpers/set-preferences (data :user-preferences)))))
+        (fn [db data]
+          (-> db
+              (assoc :session {:user-id (data :user-id)})
+              (assoc-in [:user :subscribed-tag-ids]
+                        (set (data :user-subscribed-tag-ids)))
+              (assoc :groups (key-by-id (data :user-groups)))
+              (assoc :invitations (data :invitations))
+              (assoc :threads (key-by-id (data :user-threads)))
+              (assoc :group-threads
+                     (into {}
+                           (map (fn [[g t]] [g (into #{} (map :id) t)]))
+                           (group-by :group-id (data :user-threads))))
+              (assoc-in [:user :open-thread-ids]
+                        (set (map :id (data :user-threads))))
+              (assoc :temp-threads (->> (data :user-groups)
+                                        (map :id)
+                                        (reduce (fn [memo group-id]
+                                                  (->> (schema/make-temp-thread group-id)
+                                                       (assoc memo group-id)))
+                                                {})))
+              (helpers/add-tags (data :tags))
+              (helpers/set-preferences (data :user-preferences)))))
 
        (chat/register-group-page!
-         {:key :settings
-          :view group-settings-page-view})
+        {:key :settings
+         :view group-settings-page-view})
 
        (chat/register-group-page!
-         {:key :me
-          :view me-page-view})
+        {:key :me
+         :view me-page-view})
 
        (chat/register-group-page!
-         {:key :invite
-          :view invite-page-view})
+        {:key :invite
+         :view invite-page-view})
 
        (base/register-system-page!
-         {:key :changelog
-          :view changelog-view}))))
+        {:key :changelog
+         :view changelog-view}))))

--- a/src/braid/core.clj
+++ b/src/braid/core.clj
@@ -18,7 +18,10 @@
 
 (defn start!
   "Entry point for prod"
-  ([port] (start! port env))
+  ([port] (let [env (if (:api-secret env)
+                      (assoc env :aws/credentials-provider ((juxt :api-key :api-secret) env))
+                      env)]
+            (start! port env)))
   ([port args]
    ;; modules must run first
    (when (and (= (args :environment) "prod") (empty? (args :hmac-secret)))

--- a/src/braid/core.clj
+++ b/src/braid/core.clj
@@ -18,10 +18,12 @@
 
 (defn start!
   "Entry point for prod"
-  ([port] (let [env (if (:api-secret env)
-                      (assoc env :aws/credentials-provider ((juxt :api-key :api-secret) env))
-                      env)]
-            (start! port env)))
+  ([port]
+   (start! port
+           (cond-> env
+             (env :aws-access-key)
+             (assoc :aws/credentials-provider
+                    (constantly ((juxt :aws-access-key :aws-secret-key) env))))))
   ([port args]
    ;; modules must run first
    (when (and (= (args :environment) "prod") (empty? (args :hmac-secret)))

--- a/src/braid/core/server/db.clj
+++ b/src/braid/core/server/db.clj
@@ -25,10 +25,7 @@
   (d/connect db-url))
 
 (defstate conn
-  :start (do
-           ;; txn checking uses assert, so we want to make sure they run
-           (set! *assert* true)
-           (connect config)))
+  :start (connect config))
 
 (defn db [] (d/db conn))
 
@@ -54,7 +51,7 @@
       (let [test-db (d/with (db) txns)]
         (try
           (doseq [check checks]
-            (check test-db))
+            (binding [*assert* true] (check test-db)))
           (catch AssertionError e
             (throw (ex-info "Transaction Failed"
                             {::error (.getMessage e)}))))))

--- a/src/braid/lib/s3.clj
+++ b/src/braid/lib/s3.clj
@@ -1,13 +1,13 @@
 (ns braid.lib.s3
   (:require
-    [clojure.data.json :as json]
-    [clojure.string :as string]
-    [org.httpkit.client :as http]
-    [braid.base.conf :refer [config]]
-    [braid.lib.aws :as aws])
+   [clojure.data.json :as json]
+   [clojure.string :as string]
+   [org.httpkit.client :as http]
+   [braid.base.conf :refer [config]]
+   [braid.lib.aws :as aws])
   (:import
-    (java.time.temporal ChronoUnit)
-    (org.apache.commons.codec.binary Base64 Hex)))
+   (java.time.temporal ChronoUnit)
+   (org.apache.commons.codec.binary Base64 Hex)))
 
 (defn s3-host
   [config]
@@ -122,6 +122,6 @@
   [url]
   (when url
     (or ;; old style, with bucket after domain
-      (second (re-matches #"^https://s3\.amazonaws\.com/[^/]+(/.*)$" url))
-      ;; new style, with bucket in domain
-      (second (re-matches #"^https://.+\.amazonaws\.com(/.*)$" url)))))
+     (second (re-matches #"^https://s3\.amazonaws\.com/[^/]+(/.*)$" url))
+     ;; new style, with bucket in domain
+     (second (re-matches #"^https://.+\.amazonaws\.com(/.*)$" url)))))

--- a/src/braid/lib/s3.clj
+++ b/src/braid/lib/s3.clj
@@ -10,53 +10,52 @@
    (org.apache.commons.codec.binary Base64 Hex)))
 
 (defn s3-host
-  [config]
-  (let [{:keys [bucket region]} config]
-    (str bucket ".s3." region ".amazonaws.com")))
+  [{:keys [bucket region]}]
+  (str bucket ".s3." region ".amazonaws.com"))
 
 (defn generate-s3-upload-policy
-  [config {:keys [starts-with]}]
-  (let [{:keys [api-secret api-key region bucket]} config]
-    (when api-secret
-      (let [utc-now (aws/utc-now)
-            day (.format utc-now aws/basic-date-format)
-            date (.format utc-now aws/basic-date-time-format)
-            credential (->> [api-key day region "s3" "aws4_request"]
-                            (string/join "/"))
-            policy (-> {:expiration (-> (.plus utc-now 5 ChronoUnit/MINUTES)
-                                        (.format aws/date-time-format))
-                        :conditions
-                        [{:bucket bucket}
-                         ["starts-with" "$key" starts-with]
-                         {:acl "private"}
-                         ["starts-with" "$Content-Type" ""]
-                         ["content-length-range" 0 (* 500 1024 1024)]
+  [{:aws/keys [credentials-provider] :keys [region bucket] :as config} {:keys [starts-with]}]
+  (when credentials-provider
+    (let [[api-key api-secret] (credentials-provider)
+          utc-now (aws/utc-now)
+          day (.format utc-now aws/basic-date-format)
+          date (.format utc-now aws/basic-date-time-format)
+          credential (->> [api-key day region "s3" "aws4_request"]
+                          (string/join "/"))
+          policy (-> {:expiration (-> (.plus utc-now 5 ChronoUnit/MINUTES)
+                                      (.format aws/date-time-format))
+                      :conditions
+                      [{:bucket bucket}
+                       ["starts-with" "$key" starts-with]
+                       {:acl "private"}
+                       ["starts-with" "$Content-Type" ""]
+                       ["content-length-range" 0 (* 500 1024 1024)]
 
-                         {"x-amz-algorithm" "AWS4-HMAC-SHA256"}
-                         {"x-amz-credential" credential}
-                         {"x-amz-date" date}]}
-                       json/write-str
-                       aws/str->bytes
-                       Base64/encodeBase64String)]
-        {:bucket bucket
-         :region region
-         :auth {:policy policy
-                :key api-key
-                :signature (->>
-                            (aws/str->bytes policy)
-                            (aws/hmac-sha256
-                             (aws/signing-key
-                              {:aws-api-secret api-secret
-                               :aws-region region
-                               :day day
-                               :service "s3"}))
-                            Hex/encodeHexString)
-                :credential credential
-                :date date}}))))
+                       {"x-amz-algorithm" "AWS4-HMAC-SHA256"}
+                       {"x-amz-credential" credential}
+                       {"x-amz-date" date}]}
+                     json/write-str
+                     aws/str->bytes
+                     Base64/encodeBase64String)]
+      {:bucket bucket
+       :region region
+       :auth {:policy policy
+              :key api-key
+              :signature (->>
+                          (aws/str->bytes policy)
+                          (aws/hmac-sha256
+                           (aws/signing-key
+                            {:aws-api-secret api-secret
+                             :aws-region region
+                             :day day
+                             :service "s3"}))
+                          Hex/encodeHexString)
+              :credential credential
+              :date date}})))
 
 (defn- get-signature
-  [config utc-now path query-str]
-  (let [{:keys [region api-secret bucket]} config]
+  [{:aws/keys [credentials-provider] :keys [region bucket] :as config} utc-now path query-str]
+  (let [[_ api-secret] (credentials-provider)]
     (->> ["AWS4-HMAC-SHA256"
           (.format utc-now aws/basic-date-time-format)
           (string/join "/" [(.format utc-now aws/basic-date-format) region "s3"
@@ -77,8 +76,8 @@
          aws/bytes->hex)))
 
 (defn readable-s3-url
-  [config expires-seconds path]
-  (let [{:keys [api-key region]} config
+  [{:aws/keys [credentials-provider] :keys [region] :as config} expires-seconds path]
+  (let [[api-key _] (credentials-provider)
         utc-now (aws/utc-now)
         query-str (str "X-Amz-Algorithm=AWS4-HMAC-SHA256"
                        "&X-Amz-Credential=" api-key "/" (.format utc-now aws/basic-date-format) "/" region "/s3/aws4_request"
@@ -91,8 +90,9 @@
          "&X-Amz-Signature=" (get-signature config utc-now path query-str))))
 
 (defn- make-request
-  [config {:keys [body method path] :as request}]
-  (let [utc-now (aws/utc-now)
+  [{:aws/keys [credentials-provider] :keys [region bucket] :as config} {:keys [body method path] :as request}]
+  (let [[api-key api-secret] (credentials-provider)
+        utc-now (aws/utc-now)
         {:keys [region api-secret api-key bucket]} config
         req (update request :headers
                     assoc

--- a/src/braid/lib/s3.clj
+++ b/src/braid/lib/s3.clj
@@ -54,7 +54,7 @@
                 :credential credential
                 :date date}}))))
 
-(defn get-signature
+(defn- get-signature
   [config utc-now path query-str]
   (let [{:keys [region api-secret bucket]} config]
     (->> ["AWS4-HMAC-SHA256"

--- a/src/braid/lib/upload.cljs
+++ b/src/braid/lib/upload.cljs
@@ -1,19 +1,18 @@
 (ns braid.lib.upload
   (:require
-    [clojure.string :as string]
-    [braid.lib.s3 :as s3]))
+   [clojure.string :as string]))
 
 (def regex (delay
              (re-pattern (str "https?://"
                               (-> (aget js/window "asset_domain")
                                   (string/replace "." "\\."))
-                                   "/"))))
+                              "/"))))
 
 (defn ->path [url]
   (string/replace
-    url
-    @regex
-    (str "//" (aget js/window "api_domain") "/upload/")))
+   url
+   @regex
+   (str "//" (aget js/window "api_domain") "/upload/")))
 
 (defn upload-path? [url]
   (string/includes? url (aget js/window "asset_domain")))

--- a/test/integration/braid/system_start_stop_test.clj
+++ b/test/integration/braid/system_start_stop_test.clj
@@ -1,0 +1,7 @@
+(ns integration.braid.system-start-stop-test
+  (:require [braid.core :refer :all]
+            [clojure.test :refer :all]))
+
+(deftest start-stop
+  (is (start! 0))
+  (is (stop!)))

--- a/test/unit/braid/lib/s3_test.clj
+++ b/test/unit/braid/lib/s3_test.clj
@@ -1,0 +1,37 @@
+(ns unit.braid.lib.s3-test
+  (:require
+   [braid.lib.s3 :refer :all]
+   [braid.lib.aws :as aws]
+   [org.httpkit.client :as http]
+   [clojure.test :refer :all]))
+
+(def config {:api-secret "aws-secret-key"
+             :api-key "aws-access-key"
+             :region  "aws-region"
+             :bucket "aws-bucket"})
+(deftest can-generate-s3-host
+  (is (= "aws-bucket.s3.aws-region.amazonaws.com" (s3-host config))))
+
+(deftest can-generate-s3-upload-policy
+  (let [expected {:bucket "aws-bucket"
+                  :region "aws-region"
+                  :auth {:policy "eyJleHBpcmF0aW9uIjoiMjAyMS0wMS0wMVQwMDowNTowMFoiLCJjb25kaXRpb25zIjpbeyJidWNrZXQiOiJhd3MtYnVja2V0In0sWyJzdGFydHMtd2l0aCIsIiRrZXkiLCIiXSx7ImFjbCI6InByaXZhdGUifSxbInN0YXJ0cy13aXRoIiwiJENvbnRlbnQtVHlwZSIsIiJdLFsiY29udGVudC1sZW5ndGgtcmFuZ2UiLDAsNTI0Mjg4MDAwXSx7IngtYW16LWFsZ29yaXRobSI6IkFXUzQtSE1BQy1TSEEyNTYifSx7IngtYW16LWNyZWRlbnRpYWwiOiJhd3MtYWNjZXNzLWtleVwvMjAyMTAxMDFcL2F3cy1yZWdpb25cL3MzXC9hd3M0X3JlcXVlc3QifSx7IngtYW16LWRhdGUiOiIyMDIxMDEwMVQwMDAwMDBaIn1dfQ=="
+                         :key "aws-access-key"
+                         :signature "d3230795fc4d3ffbd3387d9eb02c00250121361bb7e9a1ea68eb347a630f2634"
+                         :credential "aws-access-key/20210101/aws-region/s3/aws4_request"
+                         :date "20210101T000000Z"}}]
+    (with-redefs [aws/utc-now (constantly (java.time.ZonedDateTime/parse "2021-01-01T00:00:00Z"))]
+      (is (= expected (generate-s3-upload-policy config {:starts-with ""}))))))
+
+(deftest can-build-readable-s3-url
+  (let [expected "https://aws-bucket.s3.aws-region.amazonaws.com/dijkstra?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=aws-access-key/20210101/aws-region/s3/aws4_request&X-Amz-Date=20210101T000000Z&X-Amz-Expires=10000&X-Amz-SignedHeaders=host&X-Amz-Signature=a8f771795c835fd5f7ca75fb8ce54385cb8f591514b91d34cb34c7679fc45416"]
+    (with-redefs [aws/utc-now (constantly (java.time.ZonedDateTime/parse "2021-01-01T00:00:00Z"))]
+      (is (= expected (readable-s3-url config 10000 "dijkstra"))))))
+
+(deftest can-delete-file
+  (with-redefs [http/delete (fn [& _] (atom :irrelevant))]
+    (is (= :irrelevant (delete-file! config "/my-bucket/my-key")))))
+
+(deftest can-test-upload-url-path
+  (is (upload-url-path "https://aws-bucket.s3.aws-region.amazonaws.com/dijkstra"))
+  (is (not (upload-url-path "https://aws-bucket.s3.aws-region.something.com/dijkstra"))))

--- a/test/unit/braid/lib/s3_test.clj
+++ b/test/unit/braid/lib/s3_test.clj
@@ -5,8 +5,8 @@
    [org.httpkit.client :as http]
    [clojure.test :refer :all]))
 
-(def config {:region  "aws-region"
-             :bucket "aws-bucket"
+(def config {:aws-region  "aws-region"
+             :aws-bucket "aws-bucket"
              :aws/credentials-provider (constantly ["aws-access-key" "aws-secret-key"])})
 
 (deftest can-generate-s3-host

--- a/test/unit/braid/lib/s3_test.clj
+++ b/test/unit/braid/lib/s3_test.clj
@@ -5,10 +5,10 @@
    [org.httpkit.client :as http]
    [clojure.test :refer :all]))
 
-(def config {:api-secret "aws-secret-key"
-             :api-key "aws-access-key"
-             :region  "aws-region"
-             :bucket "aws-bucket"})
+(def config {:region  "aws-region"
+             :bucket "aws-bucket"
+             :aws/credentials-provider (constantly ["aws-access-key" "aws-secret-key"])})
+
 (deftest can-generate-s3-host
   (is (= "aws-bucket.s3.aws-region.amazonaws.com" (s3-host config))))
 


### PR DESCRIPTION
This PR provides a late binding for AWS credentials -essential for AWS role-based credentials and STS.

Despite mimicking the AWSCredentialsProvider api, this PR does not add a dependency on the AWS SDK.  At some future time it would probably be a good idea to replace the custom work in `braid.lib.aws` in favor of the SDK approach but I'm not tackling that here.